### PR TITLE
Fix POD for Schema::Index::type method

### DIFF
--- a/lib/SQL/Translator/Schema/Index.pm
+++ b/lib/SQL/Translator/Schema/Index.pm
@@ -220,7 +220,7 @@ Get or set the index's type.
 
   my $type = $index->type('unique');
 
-Get or set the index's options (e.g., "using" or "where" for PG).  Returns
+Get or set the index's type.
 
 Currently there are only four acceptable types: UNIQUE, NORMAL, FULL_TEXT,
 and SPATIAL. The latter two might be MySQL-specific. While both lowercase


### PR DESCRIPTION
Had some lingering text copied from doc for options method.
