### PR TITLE
Avoid warning about exiting sub with next

### DIFF
--- a/lib/SQL/Translator/Producer/PostgreSQL.pm
+++ b/lib/SQL/Translator/Producer/PostgreSQL.pm
@@ -583,7 +583,7 @@ sub create_index
 
     my $type = $index->type || NORMAL;
     my @fields     =  $index->fields;
-    next unless @fields;
+    return unless @fields;
 
     my $def_start = qq[CONSTRAINT ${qf}$name${qf} ];
     my $field_names = '(' . join(", ", (map { $_ =~ /\(.*\)/ ? $_ : ($qf . $_ . $qf ) } @fields)) . ')';


### PR DESCRIPTION
Get this warning from Postgres producer if you try to create an index without any fields
