### PR TITLE
Support for remaining FK ON UPDATE/ON DELETE actions

### DIFF
--- a/lib/SQL/Translator/Parser/SQLite.pm
+++ b/lib/SQL/Translator/Parser/SQLite.pm
@@ -447,10 +447,10 @@ cascade_def : cascade_update_def cascade_delete_def(?)
     cascade_delete_def cascade_update_def(?)
     { $return = {  on_delete => $item[1], on_update => $item[2][0] } }
 
-cascade_delete_def : /on\s+delete\s+(\w+)/i
+cascade_delete_def : /on\s+delete\s+(set null|set default|cascade|restrict|no action)/i
     { $return = $1}
 
-cascade_update_def : /on\s+update\s+(\w+)/i
+cascade_update_def : /on\s+update\s+(set null|set default|cascade|restrict|no action)/i
     { $return = $1}
 
 table_name : qualified_name

--- a/t/27sqlite-parser.t
+++ b/t/27sqlite-parser.t
@@ -10,7 +10,7 @@ use SQL::Translator;
 use SQL::Translator::Schema::Constants;
 
 BEGIN {
-    maybe_plan(21,
+    maybe_plan(25,
         'SQL::Translator::Parser::SQLite');
 }
 SQL::Translator::Parser::SQLite->import('parse');
@@ -74,9 +74,9 @@ $file = "$Bin/data/sqlite/named.sql";
     is( $t1->name, 'pet', "'Pet' table" );
 
     my @constraints = $t1->get_constraints;
-    is( scalar @constraints, 3, '3 constraints on pet' );
+    is( scalar @constraints, 5, '5 constraints on pet' );
 
-    my $c1 = pop @constraints;
+    my $c1 = $constraints[2];
     is( $c1->type, 'FOREIGN KEY', 'FK constraint' );
     is( $c1->reference_table, 'person', 'References person table' );
     is( $c1->name, 'fk_person_id', 'Constraint name fk_person_id' );
@@ -84,5 +84,13 @@ $file = "$Bin/data/sqlite/named.sql";
     is( $c1->on_update, 'CASCADE', 'On update cascade' );
     is( join(',', $c1->reference_fields), 'person_id',
         'References person_id field' );
+
+    my $c2 = $constraints[3];
+    is( $c2->on_delete, 'SET DEFAULT', 'On delete set default' );
+    is( $c2->on_update, 'SET NULL', 'On update set null' );
+
+    my $c3 = $constraints[4];
+    is( $c3->on_update, 'NO ACTION', 'On update no action' );
+    is( $c3->on_delete, '', 'On delete not defined' );
 
 }

--- a/t/data/sqlite/named.sql
+++ b/t/data/sqlite/named.sql
@@ -2,6 +2,10 @@ create table pet (
   "pet_id" int,
   "person_id" int
     constraint fk_person_id references person(person_id) on update CASCADE on delete RESTRICT,
+  "person_id_2" int
+    constraint fk_person_id_2 references person(person_id) on update SET NULL on delete SET DEFAULT,
+  "person_id_3" int
+    constraint fk_person_id_3 references person(person_id) on update NO ACTION,
   "name" varchar(30),
   "age" int,
   constraint age_under_100 check ( age < 100 ),


### PR DESCRIPTION
Hi,

This patch should add the missing support for ON UPDATE (resp. DELETE) SET NULL, SET DEFAULT and NO ACTION. So far only ON UPDATE CASCADE and ON UPDATE RESTRICT were implemented because they were the only ones matching the grammar (ON UPDATE \w+ did not match actions with spaces).

As a side effect it also restricts ON UPDATE <foo> and ON DELETE <foo> to only be valid actions as per the SQLite grammar here: http://www.sqlite.org/lang_createtable.html (as before this I assume ON UPDATE STUFF happily parsed to is($constraint->on_update, "STUFF")).
