### PR TITLE
add_index expects an array ref not a array ref of stringified array refs...

### DIFF
--- a/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
+++ b/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
@@ -165,7 +165,8 @@ ORDER BY 1;
 
 
             my @column_ids = split /\s+/, $$indexhash{'indkey'};
-            my @columns = split /\s+/, $$indexhash{'attname'};
+            my @columns    = (ref($$indexhash{'attname'}) eq 'ARRAY' ? @{ $$indexhash{'attname'} }
+			      : split /\s+/, $$indexhash{'attname'});
 
             $table->add_index(
                               name         => $$indexhash{'relname'},


### PR DESCRIPTION
That is to say that running 

``` bash
sqlt -f DBI --dsn 'dbi:Pg:host=<hostname>;dbname=<dbname>' --db-user '<db-user>' -t MySQL
```

results in 

``` sql
CREATE TABLE `migrate_version` (
  `repository_id` text NOT NULL,
  `repository_path` text NULL,
  `version` integer NULL,
  UNIQUE INDEX `migrate_version_pkey` (`ARRAY(0xa923264)`)
);
```

Other parsers effected is unknown and only the PostgreSQL DBI parser was investigated

This patch fixes this ensuring the result is

``` sql
CREATE TABLE `migrate_version` (
  `repository_id` text NOT NULL,
  `repository_path` text NULL,
  `version` integer NULL,
  UNIQUE INDEX `migrate_version_pkey` (`repository_id`)
);
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dbsrgits/sql-translator/24)

<!-- Reviewable:end -->
