### PR TITLE
Sql keyword field types

### DIFF
--- a/lib/SQL/Translator/Producer/Dumper.pm
+++ b/lib/SQL/Translator/Producer/Dumper.pm
@@ -221,9 +221,9 @@ for my $table ( @tables ) {
     if ( $add_truncate ) {
         print "TRUNCATE TABLE $table_name;\n";
     }
-
+    ## use dbh->quote_identifier() as a more rigourous option.
     my $sql =
-        'select ' . join(', ', map { qq["$_"] } @{ $table->{'fields'} } ) . " from $table_name"
+        'select ' . join(', ', map { $db->quote_identifier($_) } @{ $table->{'fields'} } ) . " from $table_name"
     ;
     my $sth = $db->prepare( $sql );
     $sth->execute;
@@ -233,7 +233,11 @@ for my $table ( @tables ) {
         for my $fld ( @{ $table->{'fields'} } ) {
             my $val = $rec->{ $fld };
             if ( $table->{'types'}{ $fld } eq 'string' ) {
+		## would like to be able to use dbh->quote, but that quotes
+		## according to the input database handle type.
+		## $val = $db->quote($val)
                 if ( defined $val ) {
+                    $val =~ s/\\/\\\\/g;
                     $val =~ s/'/\\'/g;
                     $val = qq['$val']
                 }


### PR DESCRIPTION
Running

``` bash
sqlt -f DBI --dsn 'dbi:Pg:host=<host>;dbname=<dbname>' --db-user <db-user> -t Dumper --producer-dsn 'dbi:Pg:host=<host>;dbname=<dbname>' --producer-db-user <db-user> > dumper.pl

perl dumper.pl --no-comments --add-truncate > dbname.data.sql
```

results in 

``` plain
DBD::Pg::st execute failed: ERROR:  syntax error at or near "desc"
LINE 1: select id, create_time, update_time, name, desc, form_values...
                                                   ^ at dumper.pl line 1665.
DBD::Pg::st execute failed: ERROR:  syntax error at or near "desc"
LINE 1: select id, create_time, update_time, name, desc, form_values...
                                                   ^ at dumper.pl line 1665.
```

This is mainly due to columns named "desc" in tables. Quoting the column names in the SELECT statement cures this. Whether this is a fix for all database engines I'm not sure.

Additionally timestamp and bytea fields are output as data type numbers, but this fails on loading into MySQL.

``` plain
ERROR 1064 (42000) at line 205: You have an error in your SQL syntax; 
```

This patch fixes both of these "features".

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dbsrgits/sql-translator/25)

<!-- Reviewable:end -->
