### PR TITLE
proposed fix for rt #83831 SQLite parser does not handle multi-word ON D...

### DIFF
--- a/lib/SQL/Translator/Parser/SQLite.pm
+++ b/lib/SQL/Translator/Parser/SQLite.pm
@@ -447,10 +447,10 @@ cascade_def : cascade_update_def cascade_delete_def(?)
     cascade_delete_def cascade_update_def(?)
     { $return = {  on_delete => $item[1], on_update => $item[2][0] } }
 
-cascade_delete_def : /on\s+delete\s+(\w+)/i
+cascade_delete_def : /on\s+delete\s+(NO ACTION|RESTRICT|SET NULL|SET DEFAULT|CASCADE)/i
     { $return = $1}
 
-cascade_update_def : /on\s+update\s+(\w+)/i
+cascade_update_def : /on\s+update\s+(NO ACTION|RESTRICT|SET NULL|SET DEFAULT|CASCADE)/i
     { $return = $1}
 
 table_name : qualified_name


### PR DESCRIPTION
This simple fix replaces the old SQLite parsing which looked for a single word action after "ON UPDATE" or "ON DELETE" by comparing against the 5 currently available actions. The fix did not break any tests. This is my first pull request at all, I hope I did it right.
