### PR TITLE
update `SQL::Translator::Schema::Field::type_mapping`.

### DIFF
--- a/lib/SQL/Translator/Schema/Field.pm
+++ b/lib/SQL/Translator/Schema/Field.pm
@@ -48,8 +48,9 @@ our %type_mapping = (
   integer => SQL_INTEGER,
   int     => SQL_INTEGER,
 
+  tinyint => SQL_TINYINT,
   smallint => SQL_SMALLINT,
-  bigint => 9999, # DBI doesn't export a constant for this. Le suck
+  bigint => SQL_BIGINT,
 
   double => SQL_DOUBLE,
 


### PR DESCRIPTION
I added `SQL_TINYINT` and `SQL_BIGINT` to `%SQL::Translator::Schema::Field::type_mapping`

I want to use `TINYINT`.

`DBI::SQL_BIGINT` is added in DBI 1.54.
