### PR TITLE
Topic/producer postgresql batch alter table

### DIFF
--- a/t/30sqlt-new-diff-pgsql.t
+++ b/t/30sqlt-new-diff-pgsql.t
@@ -55,17 +55,20 @@ CREATE TABLE added (
   id bigint
 );
 
+ALTER TABLE employee DROP CONSTRAINT FK5302D47D93FE702E;
+
+ALTER TABLE employee DROP COLUMN job_title;
+
+ALTER TABLE employee ADD CONSTRAINT FK5302D47D93FE702E_diff FOREIGN KEY (employee_id)
+  REFERENCES person (person_id) DEFERRABLE;
+
 ALTER TABLE old_name RENAME TO new_name;
 
-ALTER TABLE employee DROP CONSTRAINT FK5302D47D93FE702E;
+ALTER TABLE new_name ADD COLUMN new_field integer;
 
 ALTER TABLE person DROP CONSTRAINT UC_age_name;
 
 DROP INDEX u_name;
-
-ALTER TABLE employee DROP COLUMN job_title;
-
-ALTER TABLE new_name ADD COLUMN new_field integer;
 
 ALTER TABLE person ADD COLUMN is_rock_star smallint DEFAULT 1;
 
@@ -84,9 +87,6 @@ ALTER TABLE person ALTER COLUMN nickname TYPE character varying(24);
 ALTER TABLE person RENAME COLUMN description TO physical_description;
 
 ALTER TABLE person ADD CONSTRAINT unique_name UNIQUE (name);
-
-ALTER TABLE employee ADD CONSTRAINT FK5302D47D93FE702E_diff FOREIGN KEY (employee_id)
-  REFERENCES person (person_id) DEFERRABLE;
 
 ALTER TABLE person ADD CONSTRAINT UC_person_id UNIQUE (person_id);
 
@@ -118,13 +118,13 @@ CREATE TABLE added (
   id bigint
 );
 
-ALTER TABLE old_name RENAME TO new_name;
-
-ALTER TABLE person DROP CONSTRAINT UC_age_name;
-
 ALTER TABLE employee DROP COLUMN job_title;
 
+ALTER TABLE old_name RENAME TO new_name;
+
 ALTER TABLE new_name ADD COLUMN new_field integer;
+
+ALTER TABLE person DROP CONSTRAINT UC_age_name;
 
 ALTER TABLE person ADD COLUMN is_rock_star smallint DEFAULT 1;
 

--- a/t/postgresql-rename-table-and-field.t
+++ b/t/postgresql-rename-table-and-field.t
@@ -1,0 +1,71 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::SQL::Translator;
+use SQL::Translator;
+use SQL::Translator::Diff;
+
+maybe_plan(10, 'DBD::Pg', 'Test::PostgreSQL');
+
+my ( $pgsql, $dbh , $ddl, $ret );
+
+no warnings "once";
+$pgsql = Test::PostgreSQL->new() or die $Test::PostgreSQL::errstr;
+$dbh = DBI->connect($pgsql->dsn,'','', { RaiseError => 1 }) or die $DBI::errstr;
+use warnings "once";
+
+my $source_ddl = <<DDL;
+CREATE TABLE foo (
+    pk  SERIAL PRIMARY KEY,
+    bar VARCHAR(10)
+);
+DDL
+
+ok( $ret = $dbh->do($source_ddl), "create table" );
+
+ok( $ret = $dbh->do(q| INSERT INTO foo (bar) VALUES ('buzz') |), "insert data" );
+
+cmp_ok( $ret, '==', 1, "one row inserted" );
+
+my $target_ddl = <<DDL;
+CREATE TABLE fluff (
+    pk   SERIAL PRIMARY KEY,
+    biff VARCHAR(10)
+);
+DDL
+
+my $source_sqlt = SQL::Translator->new(
+    no_comments => 1,
+    parser   => 'SQL::Translator::Parser::PostgreSQL',
+)->translate(\$source_ddl);
+
+my $target_sqlt = SQL::Translator->new(
+    no_comments => 1,
+    parser   => 'SQL::Translator::Parser::PostgreSQL',
+)->translate(\$target_ddl);
+
+my $table = $target_sqlt->get_table('fluff');
+$table->extra( renamed_from => 'foo' );
+my $field = $table->get_field('biff');
+$field->extra( renamed_from => 'bar' );
+
+my @diff = SQL::Translator::Diff->new({
+    output_db => 'PostgreSQL',
+    source_schema => $source_sqlt,
+    target_schema => $target_sqlt,
+})->compute_differences->produce_diff_sql;
+
+foreach my $line (@diff) {
+    $line =~ s/\n//g;
+    next if $line =~ /^--/;
+    ok( $dbh->do($line), "$line" );
+}
+
+ok ( $ret = $dbh->selectall_arrayref(q(SELECT biff FROM fluff), { Slice => {} }), "query DB for data" );
+
+cmp_ok( scalar(@$ret), '==', 1, "Got 1 row");
+
+cmp_ok( $ret->[0]->{biff}, 'eq', 'buzz', "col biff has value buzz" );


### PR DESCRIPTION
This initial version makes sure that drops on old table are handled before table rename and also fixes up rename_field/alter_field so that old field table name is changed to the name of the new table to prevent calls to alter_field from croaking. Test diffs are reordered but are otherwise unchanged.
I've added a test in a separate commit which uses Test::PostgreSQL to demonstrate one specific bug that this PR fixes (GH issue #40).
