### PR TITLE
Provide default index names for SQLite

### DIFF
--- a/lib/SQL/Translator/Producer/SQLite.pm
+++ b/lib/SQL/Translator/Producer/SQLite.pm
@@ -225,7 +225,6 @@ sub create_table
     #
     # Indices
     #
-    my $idx_name_default = 'A';
     for my $index ( $table->get_indices ) {
         push @index_defs, create_index($index);
     }
@@ -233,7 +232,6 @@ sub create_table
     #
     # Constraints
     #
-    my $c_name_default = 'A';
     for my $c ( $table->get_constraints ) {
         if ($c->type eq "FOREIGN KEY") {
             push @field_defs, create_foreignkey($c);
@@ -283,14 +281,13 @@ sub create_index
 {
     my ($index, $options) = @_;
 
-    my $name   = $index->name;
-    $name      = mk_name($name);
+    (my $index_table_name = $index->table->name) =~ s/^.+?\.//; # table name may not specify schema
+    my $name   = mk_name($index->name || "${index_table_name}_idx");
 
     my $type   = $index->type eq 'UNIQUE' ? "UNIQUE " : '';
 
     # strip any field size qualifiers as SQLite doesn't like these
     my @fields = map { s/\(\d+\)$//; _generator()->quote($_) } $index->fields;
-    (my $index_table_name = $index->table->name) =~ s/^.+?\.//; # table name may not specify schema
     $index_table_name = _generator()->quote($index_table_name);
     warn "removing schema name from '" . $index->table->name . "' to make '$index_table_name'\n" if $WARN;
     my $index_def =
@@ -304,10 +301,9 @@ sub create_constraint
 {
     my ($c, $options) = @_;
 
-    my $name   = $c->name;
-    $name      = mk_name($name);
-    my @fields = map _generator()->quote($_), $c->fields;
     (my $index_table_name = $c->table->name) =~ s/^.+?\.//; # table name may not specify schema
+    my $name   = mk_name($c->name || "${index_table_name}_idx");
+    my @fields = map _generator()->quote($_), $c->fields;
     $index_table_name = _generator()->quote($index_table_name);
     warn "removing schema name from '" . $c->table->name . "' to make '$index_table_name'\n" if $WARN;
 

--- a/t/56-sqlite-producer.t
+++ b/t/56-sqlite-producer.t
@@ -164,4 +164,32 @@ $SQL::Translator::Producer::SQLite::NO_QUOTES = 0;
    is_deeply($result, $expected, 'correctly unquoted excempted DEFAULTs');
 }
 
+{
+    my $table = SQL::Translator::Schema::Table->new( name => 'foobar', fields => ['foo'] );
+
+    {
+        my $index = $table->add_index(name => 'myindex', fields => ['foo']);
+        my ($def) = SQL::Translator::Producer::SQLite::create_index($index);
+        is($def, 'CREATE INDEX "myindex" ON "foobar" ("foo")', 'index created');
+    }
+
+    {
+        my $index = $table->add_index(fields => ['foo']);
+        my ($def) = SQL::Translator::Producer::SQLite::create_index($index);
+        is($def, 'CREATE INDEX "foobar_idx" ON "foobar" ("foo")', 'index created');
+    }
+
+    {
+        my $constr = $table->add_constraint(name => 'constr', fields => ['foo']);
+        my ($def) = SQL::Translator::Producer::SQLite::create_constraint($constr);
+        is($def, 'CREATE UNIQUE INDEX "constr" ON "foobar" ("foo")', 'constraint created');
+    }
+
+    {
+        my $constr = $table->add_constraint(fields => ['foo']);
+        my ($def) = SQL::Translator::Producer::SQLite::create_constraint($constr);
+        is($def, 'CREATE UNIQUE INDEX "foobar_idx02" ON "foobar" ("foo")', 'constraint created');
+    }
+}
+
 done_testing;


### PR DESCRIPTION
The allegedly default names were never used causing the first index
created without a name to fail and subsequent indices to be named 02,
03, 04...  This uses the table name with '_idx' appended as the default,
similar to the PostgreSQL producer.
