### PR TITLE
improve add_trigger consistency between producers

### DIFF
--- a/lib/SQL/Translator/Producer/MySQL.pm
+++ b/lib/SQL/Translator/Producer/MySQL.pm
@@ -356,11 +356,14 @@ sub create_trigger {
         }
 
         my $action = $trigger->action;
-        $action .= ";" unless $action =~ /;\s*\z/;
+        if($action !~ /^\s*BEGIN\s.*\sEND\s*$/i) {
+            $action .= ";" unless $action =~ /;\s*\z/;
+            $action = "BEGIN $action END";
+        }
 
         push @statements, "DROP TRIGGER IF EXISTS " . $generator->quote($name) if $options->{add_drop_trigger};
         push @statements, sprintf(
-            "CREATE TRIGGER %s %s %s ON %s\n  FOR EACH ROW BEGIN %s END",
+            "CREATE TRIGGER %s %s %s ON %s\n  FOR EACH ROW %s",
             $generator->quote($name), $trigger->perform_action_when, $event,
             $generator->quote($trigger->on_table), $action,
         );

--- a/lib/SQL/Translator/Producer/SQLite.pm
+++ b/lib/SQL/Translator/Producer/SQLite.pm
@@ -341,7 +341,9 @@ sub create_trigger {
     $DB::single = 1;
     my $action = "";
     if (not ref $trigger->action) {
-      $action .= "BEGIN " . $trigger->action . " END";
+      $action = $trigger->action;
+      $action = "BEGIN " . $action . " END"
+        unless $action =~ /^\s*BEGIN\s.*\sEND$/i;
     }
     else {
       $action = $trigger->action->{for_each} . " "

--- a/t/56-sqlite-producer.t
+++ b/t/56-sqlite-producer.t
@@ -5,6 +5,7 @@ use strict;
 use Test::More;
 use Test::SQL::Translator qw(maybe_plan);
 
+use SQL::Translator::Schema;
 use SQL::Translator::Schema::View;
 use SQL::Translator::Schema::Table;
 use SQL::Translator::Producer::SQLite;
@@ -189,6 +190,37 @@ $SQL::Translator::Producer::SQLite::NO_QUOTES = 0;
         my $constr = $table->add_constraint(fields => ['foo']);
         my ($def) = SQL::Translator::Producer::SQLite::create_constraint($constr);
         is($def, 'CREATE UNIQUE INDEX "foobar_idx02" ON "foobar" ("foo")', 'constraint created');
+    }
+}
+
+{
+    my $schema = SQL::Translator::Schema->new();
+    my $table = $schema->add_table( name => 'foo', fields => ['bar'] );
+
+    {
+        my $trigger = $schema->add_trigger(
+            name                => 'mytrigger',
+            perform_action_when => 'before',
+            database_events     => 'update',
+            on_table            => 'foo',
+            fields              => ['bar'],
+            action              => 'BEGIN baz() END'
+        );
+        my ($def) = SQL::Translator::Producer::SQLite::create_trigger($trigger);
+        is($def, 'CREATE TRIGGER "mytrigger" before update on "foo" BEGIN baz() END', 'trigger created');
+    }
+
+    {
+        my $trigger = $schema->add_trigger(
+            name                => 'mytrigger2',
+            perform_action_when => 'after',
+            database_events     => ['insert'],
+            on_table            => 'foo',
+            fields              => ['bar'],
+            action              => 'baz()'
+        );
+        my ($def) = SQL::Translator::Producer::SQLite::create_trigger($trigger);
+        is($def, 'CREATE TRIGGER "mytrigger2" after insert on "foo" BEGIN baz() END', 'trigger created');
     }
 }
 


### PR DESCRIPTION
Update Producer::SQLite and Producer::MySQL to only wrap the trigger
action in "BEGIN...END" when the user has not already done so, bringing
them in line with other producers and the add_trigger documentation.

Fixes #46.

Signed-off-by: Andrew Gregory <andrew.gregory.8@gmail.com>