### PR TITLE
Remove empty sections

### DIFF
--- a/lib/SQL/Translator/Filter/DefaultExtra.pm
+++ b/lib/SQL/Translator/Filter/DefaultExtra.pm
@@ -69,10 +69,4 @@ if you want to set lots of things, use lots of filters!
 
 C<perl(1)>, L<SQL::Translator>
 
-=head1 BUGS
-
-=head1 TODO
-
-=head1 AUTHOR
-
 =cut

--- a/lib/SQL/Translator/Filter/Names.pm
+++ b/lib/SQL/Translator/Filter/Names.pm
@@ -99,10 +99,6 @@ __END__
 
 C<perl(1)>, L<SQL::Translator>
 
-=head1 BUGS
-
-=head1 TODO
-
 =over 4
 
 =item Name Groups
@@ -145,6 +141,5 @@ code it into the filter it's self.
 
 =back
 
-=head1 AUTHOR
 
 =cut

--- a/lib/Test/SQL/Translator.pm
+++ b/lib/Test/SQL/Translator.pm
@@ -619,8 +619,6 @@ schema file and test yaml file to compare it against.
 
 =back
 
-=head1 BUGS
-
 =head1 AUTHOR
 
 Mark D. Addison E<lt>mark.addison@itn.co.ukE<gt>,


### PR DESCRIPTION
This removes (most of, but not yet all) the `empty section in previous
paragraph` warnings.