### PR TITLE
Update JSON, YAML, & SQLite parsers to track table comments; fix YAML & JSON producers' table comments

### DIFF
--- a/lib/SQL/Translator/Parser/JSON.pm
+++ b/lib/SQL/Translator/Parser/JSON.pm
@@ -56,6 +56,10 @@ sub parse {
         for my $cdata ( @{ $tdata->{'constraints'} || [] } ) {
             $table->add_constraint( %$cdata ) or die $table->error;
         }
+
+	$table->comments( $tdata->{'comments' } )
+	    if exists $tdata->{'comments'};
+
     }
 
     #

--- a/lib/SQL/Translator/Parser/JSON.pm
+++ b/lib/SQL/Translator/Parser/JSON.pm
@@ -57,8 +57,8 @@ sub parse {
             $table->add_constraint( %$cdata ) or die $table->error;
         }
 
-	$table->comments( $tdata->{'comments' } )
-	    if exists $tdata->{'comments'};
+        $table->comments( $tdata->{'comments' } )
+            if exists $tdata->{'comments'};
 
     }
 

--- a/lib/SQL/Translator/Parser/SQLite.pm
+++ b/lib/SQL/Translator/Parser/SQLite.pm
@@ -147,7 +147,7 @@ our @EXPORT_OK = qw(parse);
 our $GRAMMAR = <<'END_OF_GRAMMAR';
 
 {
-    my ( %tables, $table_order, @table_comments, @views, @triggers );
+    my ( %tables, $table_order, @views, @triggers );
 
     sub _err {
       my $max_lines = 5;
@@ -179,8 +179,8 @@ eofile : /^\Z/
 statement : begin_transaction
     | commit
     | drop
-    | comment
     | create
+    | comment
     | /^\Z/ | { _err ($thisline, $text) }
 
 begin_transaction : /begin/i TRANSACTION(?) SEMICOLON
@@ -239,16 +239,17 @@ create : CREATE TEMPORARY(?) UNIQUE(?) INDEX NAME ON table_name parens_field_lis
 #
 # Create Table
 #
-create : CREATE TEMPORARY(?) TABLE table_name '(' definition(s /,/) ')' SEMICOLON
+create : comment(s?) CREATE TEMPORARY(?) TABLE table_name '(' definition(s /,/) ')' SEMICOLON
     {
-        my $db_name    = $item[4]->{'db_name'} || '';
-        my $table_name = $item[4]->{'name'};
+        my $db_name    = $item[5]->{'db_name'} || '';
+        my $table_name = $item[5]->{'name'};
 
         $tables{ $table_name }{'name'}         = $table_name;
-        $tables{ $table_name }{'is_temporary'} = $item[2][0] ? 1 : 0;
+        $tables{ $table_name }{'is_temporary'} = $item[3][0] ? 1 : 0;
+        $tables{ $table_name }{'comments'}     = $item[1];
         $tables{ $table_name }{'order'}        = ++$table_order;
 
-        for my $def ( @{ $item[6] } ) {
+        for my $def ( @{ $item[7] } ) {
             if ( $def->{'supertype'} eq 'column' ) {
                 push @{ $tables{ $table_name }{'fields'} }, $def;
             }

--- a/lib/SQL/Translator/Parser/YAML.pm
+++ b/lib/SQL/Translator/Parser/YAML.pm
@@ -57,8 +57,8 @@ sub parse {
             $table->add_constraint( %$cdata ) or die $table->error;
         }
 
-	$table->comments( $tdata->{'comments' } )
-	    if exists $tdata->{'comments'};
+        $table->comments( $tdata->{'comments' } )
+            if exists $tdata->{'comments'};
     }
 
     #

--- a/lib/SQL/Translator/Parser/YAML.pm
+++ b/lib/SQL/Translator/Parser/YAML.pm
@@ -56,6 +56,9 @@ sub parse {
         for my $cdata ( @{ $tdata->{'constraints'} || [] } ) {
             $table->add_constraint( %$cdata ) or die $table->error;
         }
+
+	$table->comments( $tdata->{'comments' } )
+	    if exists $tdata->{'comments'};
     }
 
     #

--- a/lib/SQL/Translator/Producer/JSON.pm
+++ b/lib/SQL/Translator/Producer/JSON.pm
@@ -72,7 +72,7 @@ sub view_table {
         'name'        => $table->name,
         'order'       => $table->order,
         'options'     => $table->options  || [],
-        $table->comments ? ('comments'    => $table->comments ) : (),
+        $table->comments ? ('comments'    => [ $table->comments ] ) : (),
         'constraints' => [
             map { view_constraint($_) } $table->get_constraints
         ],
@@ -119,8 +119,8 @@ sub view_field {
         'is_primary_key'    => scalar $field->is_primary_key,
         'is_unique'         => scalar $field->is_unique,
         $field->is_auto_increment ? ('is_auto_increment' => 1) : (),
-        $field->comments ? ('comments' => $field->comments) : (),
-        keys %{$field->extra} ? ('extra' => { $field->extra } ) : (),
+        $field->comments          ? ('comments' => [ $field->comments ]) : (),
+        keys %{$field->extra}     ? ('extra'    => { $field->extra } ) : (),
     };
 }
 
@@ -133,8 +133,8 @@ sub view_procedure {
         'sql'        => scalar $procedure->sql,
         'parameters' => scalar $procedure->parameters,
         'owner'      => scalar $procedure->owner,
-        'comments'   => scalar $procedure->comments,
-        keys %{$procedure->extra} ? ('extra' => { $procedure->extra } ) : (),
+        $procedure->comments      ? ('comments' => [ $procedure->comments ] ) : (),
+        keys %{$procedure->extra} ? ('extra'    => { $procedure->extra } ) : (),
     };
 }
 

--- a/lib/SQL/Translator/Producer/YAML.pm
+++ b/lib/SQL/Translator/Producer/YAML.pm
@@ -71,7 +71,7 @@ sub view_table {
         'name'        => $table->name,
         'order'       => $table->order,
         'options'     => $table->options  || [],
-        $table->comments ? ('comments'    => $table->comments ) : (),
+        $table->comments ? ('comments'    => [ $table->comments ] ) : (),
         'constraints' => [
             map { view_constraint($_) } $table->get_constraints
         ],
@@ -118,8 +118,8 @@ sub view_field {
         'is_primary_key'    => scalar $field->is_primary_key,
         'is_unique'         => scalar $field->is_unique,
         $field->is_auto_increment ? ('is_auto_increment' => 1) : (),
-        $field->comments ? ('comments' => $field->comments) : (),
-        keys %{$field->extra} ? ('extra' => { $field->extra } ) : (),
+        $field->comments          ? ('comments' => [ $field->comments ]) : (),
+        keys %{$field->extra}     ? ('extra'    => { $field->extra } ) : (),
     };
 }
 
@@ -132,8 +132,8 @@ sub view_procedure {
         'sql'        => scalar $procedure->sql,
         'parameters' => scalar $procedure->parameters,
         'owner'      => scalar $procedure->owner,
-        'comments'   => scalar $procedure->comments,
-        keys %{$procedure->extra} ? ('extra' => { $procedure->extra } ) : (),
+        $procedure->comments      ? ('comments' => [ $procedure->comments ] ) : (),
+        keys %{$procedure->extra} ? ('extra'    => { $procedure->extra } ) : (),
     };
 }
 

--- a/t/23json.t
+++ b/t/23json.t
@@ -22,6 +22,7 @@ my $json = to_json(from_json(<<JSON), { canonical => 1, pretty => 1 });
       "procedures" : {},
       "tables" : {
          "person" : {
+         "comments" : [ "table comment 1", "table comment 2", "table comment 3" ],
             "constraints" : [
                {
                   "deferrable" : 1,

--- a/t/24yaml.t
+++ b/t/24yaml.t
@@ -20,6 +20,10 @@ schema:
   procedures: {}
   tables:
     person:
+      comments:
+        - table comment 1
+        - table comment 2
+        - table comment 3
       constraints:
         - deferrable: 1
           expression: ''

--- a/t/27sqlite-parser.t
+++ b/t/27sqlite-parser.t
@@ -32,11 +32,11 @@ my $file = "$Bin/data/sqlite/create.sql";
     my $t1 = shift @tables;
     is( $t1->name, 'person', "'Person' table" );
     is_deeply(  [ $t1->comments ],
-		[ q(table comment 1),
-		  q(table comment 2),
-		  q(table comment 3)
-		],
-	      'person table comments' );
+                [ q(table comment 1),
+                  q(table comment 2),
+                  q(table comment 3)
+                ],
+              'person table comments' );
 
     my @fields = $t1->get_fields;
     is( scalar @fields, 6, 'Six fields in "person" table');

--- a/t/27sqlite-parser.t
+++ b/t/27sqlite-parser.t
@@ -10,7 +10,7 @@ use SQL::Translator;
 use SQL::Translator::Schema::Constants;
 
 BEGIN {
-    maybe_plan(25,
+    maybe_plan(26,
         'SQL::Translator::Parser::SQLite');
 }
 SQL::Translator::Parser::SQLite->import('parse');
@@ -31,6 +31,12 @@ my $file = "$Bin/data/sqlite/create.sql";
 
     my $t1 = shift @tables;
     is( $t1->name, 'person', "'Person' table" );
+    is_deeply(  [ $t1->comments ],
+		[ q(table comment 1),
+		  q(table comment 2),
+		  q(table comment 3)
+		],
+	      'person table comments' );
 
     my @fields = $t1->get_fields;
     is( scalar @fields, 6, 'Six fields in "person" table');

--- a/t/data/sqlite/create.sql
+++ b/t/data/sqlite/create.sql
@@ -1,3 +1,6 @@
+-- table comment 1
+-- table comment 2
+-- table comment 3
 create table person (
   person_id INTEGER PRIMARY KEY AUTOINCREMENT,
   'name' varchar(20) not null,


### PR DESCRIPTION
The SQLite, YAML & JSON parsers (trivially) didn't track table comments.  I've added that.

The YAML and JSON producers should have output comments as arrays;  for table and field comments, they could croak or generate incorrect output if there was an even number of comments.  For procedures, the comments were output as a concatenated string instead of an array.
