### PR TITLE
Removed readme_from

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,7 +54,6 @@ resources    IRC        => 'irc://irc.perl.org/#sql-translator';
 Meta->{values}{x_authority} = 'cpan:JROBINSON';
 
 all_from    'lib/SQL/Translator.pm';
-readme_from 'lib/SQL/Translator.pm';
 
 for my $type (qw/requires recommends test_requires/) {
   no strict qw/refs/;


### PR DESCRIPTION
Module::Install doesn't have readme_from,
the deleted line gives error while doing `perl Makefile.PL`

readme_from was removed from Module::Install in 2011,
so I'm sure you people must be aware of it.

If removing the usage of readme_from is not the way to go, then
I'd like to know how to run tests (because I planned to write some missing test cases, initially).
I couldn't find any documentation for
this. Please let me know if I can document anything, I will try to do!