### PR TITLE
Add deferred FKs to SQLite

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,7 +54,7 @@ resources    IRC        => 'irc://irc.perl.org/#sql-translator';
 Meta->{values}{x_authority} = 'cpan:JROBINSON';
 
 all_from    'lib/SQL/Translator.pm';
-readme_from 'lib/SQL/Translator.pm';
+#readme_from 'lib/SQL/Translator.pm';
 
 for my $type (qw/requires recommends test_requires/) {
   no strict qw/refs/;

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -54,7 +54,7 @@ resources    IRC        => 'irc://irc.perl.org/#sql-translator';
 Meta->{values}{x_authority} = 'cpan:JROBINSON';
 
 all_from    'lib/SQL/Translator.pm';
-#readme_from 'lib/SQL/Translator.pm';
+readme_from 'lib/SQL/Translator.pm';
 
 for my $type (qw/requires recommends test_requires/) {
   no strict qw/refs/;

--- a/lib/SQL/Translator/Parser/SQLite.pm
+++ b/lib/SQL/Translator/Parser/SQLite.pm
@@ -425,7 +425,7 @@ table_constraint : PRIMARY_KEY parens_field_list conflict_clause(?)
         }
     }
     |
-    FOREIGN_KEY parens_field_list REFERENCES ref_def cascade_def(?)
+    FOREIGN_KEY parens_field_list REFERENCES ref_def cascade_def(?) deferrable(?) deferred(?)
     {
       $return = {
         supertype        => 'constraint',
@@ -435,6 +435,8 @@ table_constraint : PRIMARY_KEY parens_field_list conflict_clause(?)
         reference_fields => $item[4]{'reference_fields'},
         on_delete        => $item[5][0]{'on_delete'},
         on_update        => $item[5][0]{'on_update'},
+        deferrable       => $item[6] && ($item[7]||'') eq 'deferred',
+        #deferred         => $item[6] && ($item[7]||'') eq 'deferred',
       }
     }
 
@@ -452,6 +454,15 @@ cascade_delete_def : /on\s+delete\s+(set null|set default|cascade|restrict|no ac
 
 cascade_update_def : /on\s+update\s+(set null|set default|cascade|restrict|no action)/i
     { $return = $1}
+
+not : /not/i
+
+deferrable : not(?) /deferrable/i
+    {
+        $return = ( $item[1] =~ /not/i ) ? 0 : 1;
+    }
+
+deferred : /initially/i /(deferred|immediate)/i { $item[2] }
 
 table_name : qualified_name
 

--- a/lib/SQL/Translator/Producer/SQLite.pm
+++ b/lib/SQL/Translator/Producer/SQLite.pm
@@ -282,6 +282,7 @@ sub create_foreignkey {
 
     $fk_sql .= " ON DELETE " . $c->{on_delete} if $c->{on_delete};
     $fk_sql .= " ON UPDATE " . $c->{on_update} if $c->{on_update};
+    $fk_sql .= " DEFERRABLE INITIALLY DEFERRED" if $c->deferrable;
 
     return $fk_sql;
 }

--- a/t/30sqlt-new-diff-sqlite.t
+++ b/t/30sqlt-new-diff-sqlite.t
@@ -99,7 +99,7 @@ CREATE TEMPORARY TABLE employee_temp_alter (
   position varchar(50) NOT NULL,
   employee_id int(11) NOT NULL,
   PRIMARY KEY (position, employee_id),
-  FOREIGN KEY (employee_id) REFERENCES person(person_id)
+  FOREIGN KEY (employee_id) REFERENCES person(person_id) DEFERRABLE INITIALLY DEFERRED
 );
 
 INSERT INTO employee_temp_alter( position, employee_id) SELECT position, employee_id FROM employee;
@@ -110,7 +110,7 @@ CREATE TABLE employee (
   position varchar(50) NOT NULL,
   employee_id int(11) NOT NULL,
   PRIMARY KEY (position, employee_id),
-  FOREIGN KEY (employee_id) REFERENCES person(person_id)
+  FOREIGN KEY (employee_id) REFERENCES person(person_id) DEFERRABLE INITIALLY DEFERRED
 );
 
 INSERT INTO employee SELECT position, employee_id FROM employee_temp_alter;

--- a/t/48xml-to-sqlite.t
+++ b/t/48xml-to-sqlite.t
@@ -50,7 +50,7 @@ CREATE TABLE "Basic" (
   "emptytagdef" varchar DEFAULT '',
   "another_id" int(10) DEFAULT 2,
   "timest" timestamp,
-  FOREIGN KEY ("another_id") REFERENCES "Another"("id")
+  FOREIGN KEY ("another_id") REFERENCES "Another"("id") DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE INDEX "titleindex" ON "Basic" ("title");
@@ -108,7 +108,7 @@ eq_or_diff(\@sql,
   "emptytagdef" varchar DEFAULT '',
   "another_id" int(10) DEFAULT 2,
   "timest" timestamp,
-  FOREIGN KEY ("another_id") REFERENCES "Another"("id")
+  FOREIGN KEY ("another_id") REFERENCES "Another"("id") DEFERRABLE INITIALLY DEFERRED
 )>,
           q<CREATE INDEX "titleindex" ON "Basic" ("title")>,
           q<CREATE UNIQUE INDEX "emailuniqueindex" ON "Basic" ("email")>,

--- a/t/56-sqlite-producer.t
+++ b/t/56-sqlite-producer.t
@@ -57,7 +57,7 @@ $SQL::Translator::Producer::SQLite::NO_QUOTES = 0;
         on_delete => 'RESTRICT',
         on_update => 'CASCADE',
     );
-    my $expected = [ 'FOREIGN KEY ("foreign_key") REFERENCES "foo"("id") ON DELETE RESTRICT ON UPDATE CASCADE'];
+    my $expected = [ 'FOREIGN KEY ("foreign_key") REFERENCES "foo"("id") ON DELETE RESTRICT ON UPDATE CASCADE DEFERRABLE INITIALLY DEFERRED'];
     my $result =  [SQL::Translator::Producer::SQLite::create_foreignkey($constraint,$create_opts)];
     is_deeply($result, $expected, 'correct "FOREIGN KEY"');
 }


### PR DESCRIPTION
`t/60roundtrip.t` is failing, but it fails when I back out my changes as well. It also fails for non-SQLite producers. So, I'm not certain what's going on there.