### PR TITLE
Updated MANIFEST.SKIP to include AUTHORS file.

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,4 +1,4 @@
-^(?!script/|lib/|inc/|t/|xt/|share/|Makefile.PL$|README$|MANIFEST$|Changes$|META.(?:json|yml)$)
+^(?!script/|lib/|inc/|t/|xt/|share/|Makefile.PL$|README$|MANIFEST$|Changes$|AUTHORS$|META.(?:json|yml)$)
 
 .*CVS.*
 .#.*


### PR DESCRIPTION
Hi @dbsrgits,

The link to AUTHORS file is broken in the pod document of the package SQL::Translator under the section "AUTHORS". I noticed the AUTHORS file is not included in the distribution and hence the link is broken.

Please review the above changes.

Many Thanks.

Best Regards,
Mohammad S Anwar