### PR TITLE
MySQL Parser understands VIEWs with a field list.

### DIFF
--- a/lib/SQL/Translator/Parser/MySQL.pm
+++ b/lib/SQL/Translator/Parser/MySQL.pm
@@ -326,7 +326,7 @@ create : CREATE PROCEDURE NAME not_delimiter "$delimiter"
 PROCEDURE : /procedure/i
     | /function/i
 
-create : CREATE or_replace(?) create_view_option(s?) /view/i NAME /as/i view_select_statement "$delimiter"
+create : CREATE or_replace(?) create_view_option(s?) /view/i NAME parens_field_list(?) /as/i view_select_statement "$delimiter"
     {
         @table_comments = ();
         my $view_name   = $item{'NAME'};

--- a/t/02mysql-parser.t
+++ b/t/02mysql-parser.t
@@ -502,6 +502,19 @@ BEGIN {
     is( join(',', $t2c2->reference_fields), 'id', 'To field "id"' );
 }
 
+# Tests for CREATE VIEW statements that contain a column list
+# after the view name
+{
+    my $tr = SQL::Translator->new();
+    my $data = parse($tr,
+        q[
+            CREATE
+              VIEW view_foo (id, name) AS
+                SELECT id, name FROM thing;
+        ]
+    ) or die $tr->error;
+}
+
 # cch Tests for:
 #    comments like: /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 #    char fields with character set and collate qualifiers


### PR DESCRIPTION
Updates the MySQL parser to properly parse CREATE VIEW statements that
contain a field list after the view name. This allows the parser
to understand statements created by the MySQL producer.

Prior to this change, this statement would be parsed properly:

    CREATE
      VIEW view_foo AS
        SELECT id, name FROM thing;

But this one would not:

    CREATE
      VIEW view_foo (id, name) AS
        SELECT id, name FROM thing;

(The latter statement is the same one added to the tests in this PR. It's taken directly from the mysql producer tests.)