### PR TITLE
Fixed a terrible diff issue case of PostgreSQL

### DIFF
--- a/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
+++ b/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
@@ -37,17 +37,16 @@ sub parse {
     my $schema = $tr->schema;
 
     my $column_select = $dbh->prepare(
-      "SELECT a.attname, case 
+      "SELECT a.attname, case
           when t.oid = any ('{int,int8,int2}'::regtype[])
           and ad.adsrc = 'nextval('''
-                || (pg_get_serial_sequence (a.attrelid::regclass::text
-                                          , a.attname))::regclass
+                || (pg_get_serial_sequence (a.attrelid::regclass::text, a.attname))::regclass
                 || '''::regclass)'
          then case t.oid
              when 'int8'::regtype then 'bigserial'
              when 'int'::regtype  then 'serial'
              when 'int2'::regtype then 'smallserial'
-         end 
+         end
          else format_type(t.oid, a.atttypmod)
          end as typname, a.attnum,
              case typname

--- a/lib/SQL/Translator/Parser/PostgreSQL.pm
+++ b/lib/SQL/Translator/Parser/PostgreSQL.pm
@@ -589,6 +589,15 @@ pg_data_type :
             };
         }
     |
+    /(smallserial|serial2)/i
+        {
+            $return = {
+                type              => 'integer',
+                size              => 5,
+                is_auto_increment => 1
+            };
+        }
+    |
     /(bit varying|varbit)/i
         {
             $return = { type => 'varbit' };

--- a/lib/SQL/Translator/Producer/PostgreSQL.pm
+++ b/lib/SQL/Translator/Producer/PostgreSQL.pm
@@ -689,12 +689,22 @@ sub convert_datatype
         @size = ();
     }
 
-    if (defined $size[0] && $size[0] > 0 && $data_type =~ /^time/i ) {
-        $data_type =~ s/^(time.*?)( with.*)?$/$1($size[0])/;
-        $data_type .= $2 if(defined $2);
+    if ( $data_type =~ /^(time(?:[a-z]+)?)/i ) {
+        my $time_type = $1;
+        if (defined $size[0] && 0 < $size[0]) {
+            $time_type .= "($size[0])";
+        }
+        if ($data_type =~ /((?:with|without)? time zone)$/i) {
+            $time_type .= " $1";
+        } else {
+            $time_type .= ' without time zone';
+        }
+        $data_type = $time_type;
     } elsif ( defined $size[0] && $size[0] > 0 ) {
+        $data_type =~ s/\([0-9]+\)$//; # Bug fix for type(size)(size)
         $data_type .= '(' . join( ',', @size ) . ')';
     }
+    
     if($array)
     {
         $data_type .= '[]';

--- a/lib/SQL/Translator/Producer/PostgreSQL.pm
+++ b/lib/SQL/Translator/Producer/PostgreSQL.pm
@@ -704,7 +704,6 @@ sub convert_datatype
         $data_type =~ s/\([0-9]+\)$//; # Bug fix for type(size)(size)
         $data_type .= '(' . join( ',', @size ) . ')';
     }
-    
     if($array)
     {
         $data_type .= '[]';
@@ -782,7 +781,6 @@ sub alter_field
                        $to_field->name),
                        $to_dt eq 'serial' ? 'integer' : "$1int"
                     );
-            
             my $seq_name = "${table_name}_${field_name}_seq";
             my $by_name = "${table_name}.${field_name}";
             my @args = map(

--- a/t/30sqlt-new-diff-pgsql.t
+++ b/t/30sqlt-new-diff-pgsql.t
@@ -72,7 +72,13 @@ DROP INDEX "u_name";
 
 ALTER TABLE "person" ADD COLUMN "is_rock_star" smallint DEFAULT 1;
 
-ALTER TABLE "person" ALTER COLUMN "person_id" TYPE serial;
+ALTER TABLE "person" ALTER COLUMN "person_id" TYPE integer;
+
+CREATE SEQUENCE "person_person_id_seq";
+
+ALTER TABLE "person" ALTER COLUMN "person_id" SET DEFAULT nextval('person_person_id_seq');
+
+ALTER SEQUENCE "person_person_id_seq" OWNED BY "person"."person_id";
 
 ALTER TABLE "person" ALTER COLUMN "name" SET NOT NULL;
 
@@ -127,7 +133,13 @@ ALTER TABLE person DROP CONSTRAINT UC_age_name;
 
 ALTER TABLE person ADD COLUMN is_rock_star smallint DEFAULT 1;
 
-ALTER TABLE person ALTER COLUMN person_id TYPE serial;
+ALTER TABLE person ALTER COLUMN person_id TYPE integer;
+
+CREATE SEQUENCE person_person_id_seq;
+
+ALTER TABLE person ALTER COLUMN person_id SET DEFAULT nextval('person_person_id_seq');
+
+ALTER SEQUENCE person_person_id_seq OWNED BY person.person_id;
 
 ALTER TABLE person ALTER COLUMN name SET NOT NULL;
 

--- a/t/46xml-to-pg.t
+++ b/t/46xml-to-pg.t
@@ -45,7 +45,7 @@ CREATE TABLE "Basic" (
   -- Hello emptytagdef
   "emptytagdef" character varying DEFAULT '',
   "another_id" integer DEFAULT 2,
-  "timest" timestamp,
+  "timest" timestamp without time zone,
   PRIMARY KEY ("id"),
   CONSTRAINT "emailuniqueindex" UNIQUE ("email"),
   CONSTRAINT "very_long_index_name_on_title_field_which_should_be_truncated_for_various_rdbms" UNIQUE ("title")

--- a/t/47postgres-producer.t
+++ b/t/47postgres-producer.t
@@ -292,7 +292,7 @@ my $field3 = SQL::Translator::Schema::Field->new( name      => 'time_field',
 
 my $field3_sql = SQL::Translator::Producer::PostgreSQL::create_field($field3);
 
-is($field3_sql, 'time_field time NOT NULL', 'Create time field works');
+is($field3_sql, 'time_field time without time zone NOT NULL', 'Create time field works');
 
 my $field3_datetime_with_TZ = SQL::Translator::Schema::Field->new(
     name      => 'datetime_with_TZ',
@@ -496,7 +496,7 @@ my $field12 = SQL::Translator::Schema::Field->new( name => 'time_field',
 
 my $field12_sql = SQL::Translator::Producer::PostgreSQL::create_field($field12,{ postgres_version => 8.3 });
 
-is($field12_sql, 'time_field timestamp NOT NULL', 'time with precision');
+is($field12_sql, 'time_field timestamp without time zone NOT NULL', 'time with precision');
 
 my $field13 = SQL::Translator::Schema::Field->new( name => 'enum_field_with_type_name',
                                                    table => $table,

--- a/t/66-postgres-dbi-parser.t
+++ b/t/66-postgres-dbi-parser.t
@@ -91,7 +91,7 @@ is( scalar @t1_fields, 4, '4 fields in sqlt_test1' );
 
 my $f1 = shift @t1_fields;
 is( $f1->name, 'f_serial', 'First field is "f_serial"' );
-is( $f1->data_type, 'integer', 'Field is an integer' );
+is( $f1->data_type, 'serial', 'Field is a serial' );
 is( $f1->is_nullable, 0, 'Field cannot be null' );
 is( $f1->default_value, "nextval('sqlt_test1_f_serial_seq'::regclass)", 'Default value is nextval()' );
 is( $f1->is_primary_key, 1, 'Field is PK' );
@@ -102,8 +102,7 @@ my $f2 = shift @t1_fields;
 is( $f2->name, 'f_varchar', 'Second field is "f_varchar"' );
 is( $f2->data_type, 'character varying(255)', 'Field is a character varying(255)' );
 is( $f2->is_nullable, 1, 'Field can be null' );
-#FIXME: should not be 255?
-is( $f2->size, 259, 'Size is "259"' );
+is( $f2->size, 255, 'Size is "255"' );
 is( $f2->default_value, undef, 'Default value is undefined' );
 is( $f2->is_primary_key, 0, 'Field is not PK' );
 is( $f2->is_auto_increment, 0, 'Field is not auto increment' );


### PR DESCRIPTION
## Why terrible?

- It outputs syntax that will result in an error when executed.
`ALTER TABLE tablename ALTER colname TYPE serial;`
- When parsing from DBI, unexpected types are returned
- Similarly, unexpected sizes are returned
- There is no type match for time

## What I did?

- I rewrote SQL to solve the above problem.
- Added a dedicated parser statement for `smallserial`.
- When type like serial, we modified it to use `CREATE SEQUENCE` instead of `ALTER`.

Best regard 👍 