### PR TITLE
WIP: quoting of identifiers in diff, SQLite and test

### DIFF
--- a/lib/SQL/Translator/Producer/SQLite.pm
+++ b/lib/SQL/Translator/Producer/SQLite.pm
@@ -386,10 +386,11 @@ sub create_trigger {
 sub alter_table { () } # Noop
 
 sub add_field {
-  my ($field) = @_;
+  my ($field,$options) = @_;
 
   return sprintf("ALTER TABLE %s ADD COLUMN %s",
-      _generator()->quote($field->table->name), create_field($field))
+      _generator($options)->quote($field->table->name),
+      create_field($field, $options))
 }
 
 sub alter_create_index {

--- a/t/XX-quote-diff.t
+++ b/t/XX-quote-diff.t
@@ -1,0 +1,63 @@
+use v5.24.0;
+use warnings;
+
+use SQL::Translator;
+use SQL::Translator::Diff;
+
+use Test::More;
+
+sub schema_pair {
+  my $y1 = <<'Y1';
+---
+schema:
+  tables:
+    foo:
+      name: foo
+      fields:
+        foo: { order: 1, name: foo, data_type: varchar, size: 36 }
+Y1
+
+  my $y2 = <<'Y2';
+---
+schema:
+  tables:
+    foo:
+      name: foo
+      fields:
+        foo: { order: 1, name: foo, data_type: varchar, size: 36 }
+        bar: { order: 2, name: bar, data_type: varchar, size: 36 }
+Y2
+
+  my $t1 = SQL::Translator->new(parser => "YAML", quote_identifiers => 1);
+  $t1->translate(\$y1);
+
+  my $t2 = SQL::Translator->new(parser => "YAML", quote_identifiers => 1);
+  $t2->translate(\$y2);
+
+  return ($t1->schema, $t2->schema);
+}
+
+for my $test (
+  [ MySQL       => sub { "`$_[0]`" }   ],
+  [ PostgreSQL  => sub { qq{"$_[0]"} } ],
+  [ SQLite      => sub { qq{"$_[0]"} } ],
+) {
+  my ($producer, $q) = @$test;
+
+  my ($s1, $s2) = schema_pair;
+
+  my $sql = SQL::Translator::Diff::schema_diff(
+    $s1, $producer,
+    $s2, $producer,
+    { producer_args => { quote_identifiers => 1 } },
+  );
+
+  my $quoted = $q->('bar');
+  like(
+    $sql,
+    qr{ADD COLUMN \Q$quoted\E},
+    "$producer: new column name is quoted",
+  );
+}
+
+done_testing;


### PR DESCRIPTION
In production, we found that the stable CPAN release of the PostgreSQL
producer did not quote identifiers in diffs.  We diagnosed the problem
and wrote a fix, only to see it was fixed in master.  Oh well, we
learned some more about SQLT!

I had adapted my test to run against a few producers, and found that
SQLite didn't work, even in master.  The first cause seemed like the
same bug as I found in PostgreSQL:  add_field did not pass its options
to the generator to inform its quoting.  I have fixed that in the patch,
but it still fails.

The fundamental problem appears to be the weird (to me) `$NO_QUOTES`
behavior.  That variable is set in `->produce`, a method that *does not
seem to be called* in the execution of the test program.  At that point,
I gave up for now, but I wanted to file this issue.