### PR TITLE
Improve create_index

### DIFF
--- a/lib/SQL/Translator/Producer/PostgreSQL.pm
+++ b/lib/SQL/Translator/Producer/PostgreSQL.pm
@@ -1088,7 +1088,13 @@ sub alter_create_index {
   my ($index, $options) = @_;
   my $generator = _generator($options);
   my ($idef, $constraints) = create_index($index, $options);
-  return $index->type eq NORMAL
+
+  # Just like 90726ffd commit: don't run into output like this:
+  # ALTER TABLE users ADD ;
+  # create_index returns one of: index definition or constraint
+
+  # So define index or constraint
+  return $idef
       ? $idef
       : sprintf('ALTER TABLE %s ADD %s', $generator->quote($index->table->name), join(q{}, @$constraints));
 }


### PR DESCRIPTION
`alter_create_index` may have two scenarios:

1. CREATE INDEX ...
2. ALTER TABLE ...

This scenario depend on is `$idef` returned or not.

When index definition is returned we `CREATE INDEX` in other case we `ALTER TABLE`