### PR TITLE
Implement EXCLUDE constraint for PostgreSQL

### DIFF
--- a/lib/SQL/Translator/Producer/PostgreSQL.pm
+++ b/lib/SQL/Translator/Producer/PostgreSQL.pm
@@ -601,6 +601,15 @@ sub create_constraint
 
         push @fks, "$def";
     }
+    elsif( $c->type eq EXCLUDE ) {
+        my $using      =  $c->options->[0]{ using };
+        $using =  $using ? "USING $using" : '';
+        my $expression =  $c->expression;
+        my $where      =  $c->options->[0]{ where };
+        $where =  $where ? "WHERE $where" : '';
+        push @constraint_defs, "$def_start EXCLUDE $using ( $expression ) $where";
+    }
+
 
     return \@constraint_defs, \@fks;
 }

--- a/lib/SQL/Translator/Schema/Constants.pm
+++ b/lib/SQL/Translator/Schema/Constants.pm
@@ -35,6 +35,8 @@ This module exports the following constants for Schema features;
 
 =item UNIQUE
 
+=item EXCLUDE
+
 =back
 
 =cut
@@ -55,6 +57,7 @@ our @EXPORT = qw[
     NULL
     PRIMARY_KEY
     UNIQUE
+    EXCLUDE
 ];
 
 #
@@ -77,6 +80,8 @@ use constant NULL => 'NULL';
 use constant PRIMARY_KEY => 'PRIMARY KEY';
 
 use constant UNIQUE => 'UNIQUE';
+
+use constant EXCLUDE => 'EXCLUDE';
 
 1;
 

--- a/lib/SQL/Translator/Schema/Constraint.pm
+++ b/lib/SQL/Translator/Schema/Constraint.pm
@@ -40,6 +40,7 @@ my %VALID_CONSTRAINT_TYPE = (
     CHECK_C,     1,
     FOREIGN_KEY, 1,
     NOT_NULL,    1,
+    EXCLUDE,     1,
 );
 
 =head2 new


### PR DESCRIPTION
This pull request will allow to generate next statement

    ALTER TABLE subnets ADD CONSTRAINT subnets_subnet_udx  EXCLUDE USING gist ( subnet inet_ops with && ) WHERE state = 0;


with next syntax:

	$sqlt_table->add_constraint(
		name       =>  'subnets_subnet_udx',
		type       =>  'exclude',
		fields     =>  'subnet',
		expression =>  'subnet inet_ops with &&',
		options    =>  { using => 'gist', where => 'state = 0' },
	);
