### PR TITLE
avoid conditional variable declaration

### DIFF
--- a/lib/SQL/Translator/Producer/SQLite.pm
+++ b/lib/SQL/Translator/Producer/SQLite.pm
@@ -66,7 +66,8 @@ sub produce {
     local $NO_QUOTES = 0
       if $translator->quote_identifiers and $translator->quote_identifiers ne '0E0';
 
-    my $head = (header_comment() . "\n") unless $no_comments;
+    my $head;
+    $head = (header_comment() . "\n") unless $no_comments;
 
     my @create = ();
 


### PR DESCRIPTION
perldoc perlsyn:

> The behaviour of a `my`, `state`, or `our` modified with a statement modifier conditional or loop construct (for example, `my $x if ...` ) is **undefined**.