### PR TITLE
Remove size on floating point data types during MySQL field normalization

### DIFF
--- a/lib/SQL/Translator/Parser/MySQL.pm
+++ b/lib/SQL/Translator/Parser/MySQL.pm
@@ -1104,13 +1104,18 @@ sub normalize_field {
             $changed = $size != 20;
             $size = 20;
         }
-        elsif ( lc $type =~ /(float|double|decimal|numeric|real|fixed|dec)/ ) {
+        elsif ( lc $type =~ /(decimal|numeric|fixed|dec)/ ) {
             my $old_size = (ref $size || '') eq 'ARRAY' ? $size : [];
             $changed     = @$old_size != 2
                         || $old_size->[0] != 8
                         || $old_size->[1] != 2;
             $size        = [8,2];
         }
+    }
+
+    if( $type =~ /^(float|double|real)$/i ) {
+        $changed = $size;
+        $size    = undef;
     }
 
     if ( $type =~ /^tiny(text|blob)$/i ) {

--- a/t/30sqlt-new-diff-mysql.t
+++ b/t/30sqlt-new-diff-mysql.t
@@ -17,14 +17,12 @@ plan tests => 9;
 
 use_ok('SQL::Translator::Diff') or die "Cannot continue\n";
 
-my $tr = SQL::Translator->new;
-
-my ( $source_schema, $target_schema, $parsed_sql_schema ) = map {
+my ( $source_schema, $target_schema ) = map {
     my $t = SQL::Translator->new;
     $t->parser( 'YAML' )
-      or die $tr->error;
+      or die $t->error;
     my $out = $t->translate( catfile($Bin, qw/data diff/, $_ ) )
-      or die $tr->error;
+      or die $t->error;
 
     my $schema = $t->schema;
     unless ( $schema->name ) {
@@ -161,9 +159,9 @@ eq_or_diff($out, <<'## END OF DIFF', "No differences found");
 {
   my $t = SQL::Translator->new;
   $t->parser( 'MySQL' )
-    or die $tr->error;
+    or die $t->error;
   my $out = $t->translate( catfile($Bin, qw/data mysql create.sql/ ) )
-    or die $tr->error;
+    or die $t->error;
 
   # Lets remove the renamed table so we dont have to change the SQL or other tests
   $target_schema->drop_table('new_name');
@@ -199,7 +197,7 @@ ALTER TABLE employee DROP FOREIGN KEY FK5302D47D93FE702E,
 ALTER TABLE person DROP INDEX UC_age_name,
                    DROP INDEX u_name,
                    ADD COLUMN is_rock_star tinyint(4) NULL DEFAULT 1,
-                   ADD COLUMN value double(8, 2) NULL DEFAULT 0.00,
+                   ADD COLUMN value double NULL DEFAULT 0.00,
                    CHANGE COLUMN person_id person_id integer(11) NOT NULL auto_increment,
                    CHANGE COLUMN name name varchar(20) NOT NULL,
                    CHANGE COLUMN age age integer(11) NULL DEFAULT 18,

--- a/t/30sqlt-new-diff-sqlite.t
+++ b/t/30sqlt-new-diff-sqlite.t
@@ -128,7 +128,7 @@ CREATE TEMPORARY TABLE person_temp_alter (
   weight double(11,2),
   iq int(11) DEFAULT 0,
   is_rock_star tinyint(4) DEFAULT 1,
-  value double(8,2) DEFAULT 0.00,
+  value double DEFAULT 0.00,
   physical_description text
 );
 
@@ -143,7 +143,7 @@ CREATE TABLE person (
   weight double(11,2),
   iq int(11) DEFAULT 0,
   is_rock_star tinyint(4) DEFAULT 1,
-  value double(8,2) DEFAULT 0.00,
+  value double DEFAULT 0.00,
   physical_description text
 );
 

--- a/t/data/diff/create1.yml
+++ b/t/data/diff/create1.yml
@@ -215,8 +215,7 @@ schema:
           name: value
           order: 7
           size:
-            - 8
-            - 2
+            - 0
       indices:
         - fields:
             - name

--- a/t/data/diff/create2.yml
+++ b/t/data/diff/create2.yml
@@ -226,8 +226,7 @@ schema:
           name: value
           order: 7
           size:
-            - 8
-            - 2
+            - 0
       indices:
         - fields:
             - name


### PR DESCRIPTION
**Summary:**
This merge request removes the forced 2 precision and 8 digits size limit for floating point number data types in the MySQL field normalization and instead force removes size for these data types.

Some unit tests are updated to reflect this change.

**Reason for this change:**
While sane size limits are useful for fixed point data types like decimal such limits make little sense for floating point data types. Setting the size for floating point data types does not result in less storage being used but will just try to badly truncate the input and mask the output (or raise an error in strict mode on bad input).

For use cases where size restricted data is required or desired it is highly recommended to use fixed point data types as they don't have impression errors in their given number space as opposed to IEEE 754 floating point numbers (As an example: 0.1 and 0.2 are not directly representable as IEEE 754 number no matter how good the precision is). IEEE 754 floating point numbers are simply not designed for such use cases but to closer approximate natural numbers.

Being able to set size limits to floating point numbers can also encourage the use of bad practices like the classic case of money represented as floating point numbers.

Lastly, the MySQL documentation recommends not using precision and number of digits for maximum portability.
https://dev.mysql.com/doc/refman/en/floating-point-types.html