### PR TITLE
Fix passing of producer args from SQL::Translator::Diff.

### DIFF
--- a/lib/SQL/Translator/Diff.pm
+++ b/lib/SQL/Translator/Diff.pm
@@ -272,8 +272,7 @@ sub produce_diff_sql {
         producer_type => $self->output_db,
         add_drop_table => 0,
         no_comments => 1,
-        # TODO: sort out options
-        %{ $self->producer_args }
+        producer_args => $self->producer_args,
       );
       $translator->producer_args->{no_transaction} = 1;
       my $schema = $translator->schema;


### PR DESCRIPTION
Otherwise the producer args are present for changed fields, but not for
created tables.

So changing the questionable default for the MySQL version in the MySQL
producer results in a different SQL types depending if the field is a new
or an existing table.