### PR TITLE
Fix Travis builds by asking for postgres

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,5 @@ before_script:
   - psql -U postgres -c 'create database sqlt_test;'
 script:
   - perl Makefile.PL && make test
+services:
+  - postgresql

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,7 +3,7 @@ use warnings;
 use ExtUtils::MakeMaker;
 use File::ShareDir::Install;
 do './maint/Makefile.PL.include' or die $@
-  unless -f 'META.yml';
+  unless -f 'META.yml' && -f 't/data/roundtrip_autogen.yaml';
 my $eumm_version = eval $ExtUtils::MakeMaker::VERSION;
 
 my %eumm_args = (


### PR DESCRIPTION
Travis builds are currently failing with
```
The command "psql -U postgres -c 'create database sqlt_test;'" failed and exited with 2 during .
```
eg., https://travis-ci.org/davel/sql-translator/jobs/624123545

This change requests for postgres to be available.

The tests on Perl 5.16 and 5.18 are also failing because insufficient dependencies are installed the first time Makefile.PL is invoked, so that the test data does not get generated. A second change causes the test data to be generated if it is not present on the second run of Makefile.PL.