### PR TITLE
sqlt-diff: Add option --mysql-producer-version

### DIFF
--- a/script/sqlt-diff
+++ b/script/sqlt-diff
@@ -46,6 +46,7 @@ Options:
   --ignore-constraint-names   Ignore constraint name differences
   --mysql_parser_version=<#####> Specify a target MySQL parser version
                                  for dealing with /*! comments
+  --mysql-producer-version=<#####> Specify a target MySQL producer version
   --output-db=<Producer>  This Producer will be used instead of one
                           corresponding to parser1 to format output
                           for new tables
@@ -117,7 +118,7 @@ use vars qw( $VERSION );
 $VERSION = '1.66';
 
 my (@input, $list, $help, $debug, $trace, $caseopt, $ignore_index_names, $ignore_constraint_names, $output_db,
-  $mysql_parser_version, $ignore_view_sql, $ignore_proc_sql, $no_batch_alters, $quote);
+  $mysql_parser_version, $mysql_producer_version, $ignore_view_sql, $ignore_proc_sql, $no_batch_alters, $quote);
 
 GetOptions(
   'l|list'                  => \$list,
@@ -128,6 +129,7 @@ GetOptions(
   'ignore-index-names'      => \$ignore_index_names,
   'ignore-constraint-names' => \$ignore_constraint_names,
   'mysql_parser_version:s'  => \$mysql_parser_version,
+  'mysql-producer-version:s'=> \$mysql_producer_version,
   'output-db:s'             => \$output_db,
   'ignore-view-sql'         => \$ignore_view_sql,
   'ignore-proc-sql'         => \$ignore_proc_sql,
@@ -195,6 +197,7 @@ my $result = SQL::Translator::Diff::schema_diff(
     sqlt_args               => {
       quote_table_names => $quote || '',
       quote_field_names => $quote || '',
+      mysql_version     => $mysql_producer_version,
     },
   }
 );


### PR DESCRIPTION
Analog to the sqlt script, allow to specify the MySQL producer version.

Stops converting varchar(>255) to text columns for version>5.000003