### PR TITLE
pg_attrdef.adsrc no longer on Pg12+

### DIFF
--- a/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
+++ b/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
@@ -38,7 +38,7 @@ sub parse {
 
     my $column_select = $dbh->prepare(
       "SELECT a.attname, format_type(t.oid, a.atttypmod) as typname, a.attnum,
-              a.atttypmod as length, a.attnotnull, a.atthasdef, ad.adsrc,
+              a.atttypmod as length, a.attnotnull, a.atthasdef, pg_get_expr(ad.adbin, ad.adrelid) as adsrc,
               d.description
        FROM pg_type t, pg_attribute a
        LEFT JOIN pg_attrdef ad ON (ad.adrelid = a.attrelid AND a.attnum = ad.adnum)


### PR DESCRIPTION
pg_get_expr() is available back to Pg7.4 at least

Right now the SQL here will fail if using the newest Postgresql.  Not sure if backcompat to 7.4 is good enough or not.