### PR TITLE
Turned off foreign key checking in MySQL.

### DIFF
--- a/lib/SQL/Translator/Diff.pm
+++ b/lib/SQL/Translator/Diff.pm
@@ -295,8 +295,10 @@ sub produce_diff_sql {
     }
 
     if (@diffs) {
-      unshift @diffs, "BEGIN";
-      push    @diffs, "\nCOMMIT";
+      my $begin_cmd = $producer_class->can('begin_commands') ? $producer_class->begin_commands() : "BEGIN";
+      my $commit_cmd = $producer_class->can('commit_commands') ? $producer_class->commit_commands() : "\nCOMMIT";
+      unshift @diffs, $begin_cmd;
+      push    @diffs, $commit_cmd;
     } else {
       @diffs = ("-- No differences found");
     }

--- a/t/30sqlt-new-diff-mysql.t
+++ b/t/30sqlt-new-diff-mysql.t
@@ -58,8 +58,6 @@ CREATE TABLE added (
   id integer(11) NULL
 );
 
-SET foreign_key_checks=1;
-
 ALTER TABLE old_name RENAME TO new_name;
 
 ALTER TABLE employee DROP FOREIGN KEY FK5302D47D93FE702E;
@@ -99,6 +97,8 @@ ALTER TABLE deleted DROP FOREIGN KEY fk_fake;
 DROP TABLE deleted;
 
 
+SET foreign_key_checks=1;
+
 COMMIT;
 
 ## END OF DIFF
@@ -120,8 +120,6 @@ CREATE TABLE added (
   id integer(11) NULL
 );
 
-SET foreign_key_checks=1;
-
 ALTER TABLE employee DROP COLUMN job_title;
 
 ALTER TABLE old_name RENAME TO new_name,
@@ -142,6 +140,8 @@ ALTER TABLE deleted DROP FOREIGN KEY fk_fake;
 
 DROP TABLE deleted;
 
+
+SET foreign_key_checks=1;
 
 COMMIT;
 
@@ -190,8 +190,6 @@ CREATE TABLE added (
   id integer(11) NULL
 );
 
-SET foreign_key_checks=1;
-
 ALTER TABLE employee DROP FOREIGN KEY FK5302D47D93FE702E,
                      DROP CONSTRAINT demo_constraint,
                      DROP COLUMN job_title,
@@ -213,6 +211,8 @@ ALTER TABLE person DROP CONSTRAINT UC_age_name,
 
 DROP TABLE deleted;
 
+
+SET foreign_key_checks=1;
 
 COMMIT;
 
@@ -257,12 +257,16 @@ COMMIT;
 
 BEGIN;
 
+SET foreign_key_checks=0;
+
 ALTER TABLE employee DROP FOREIGN KEY FK5302D47D93FE702E_diff;
 
 ALTER TABLE employee ADD COLUMN new integer NULL,
                      ADD CONSTRAINT FK5302D47D93FE702E_diff FOREIGN KEY (employee_id) REFERENCES person (person_id) ON DELETE CASCADE,
                      ADD CONSTRAINT new_constraint FOREIGN KEY (employee_id) REFERENCES patty (fake);
 
+
+SET foreign_key_checks=1;
 
 COMMIT;
 
@@ -308,6 +312,8 @@ COMMIT;
 
 BEGIN;
 
+SET foreign_key_checks=0;
+
 ALTER TABLE employee RENAME TO fnord,
                      DROP FOREIGN KEY bar_fk,
                      ADD CONSTRAINT foo_fk FOREIGN KEY (employee_id) REFERENCES foo (id);
@@ -316,6 +322,8 @@ ALTER TABLE deleted DROP FOREIGN KEY fk_fake;
 
 DROP TABLE deleted;
 
+
+SET foreign_key_checks=1;
 
 COMMIT;
 
@@ -330,6 +338,8 @@ COMMIT;
 
 BEGIN;
 
+SET foreign_key_checks=0;
+
 ALTER TABLE `employee` RENAME TO `fnord`,
                        DROP FOREIGN KEY `bar_fk`,
                        ADD CONSTRAINT `foo_fk` FOREIGN KEY (`employee_id`) REFERENCES `foo` (`id`);
@@ -338,6 +348,8 @@ ALTER TABLE `deleted` DROP FOREIGN KEY `fk_fake`;
 
 DROP TABLE `deleted`;
 
+
+SET foreign_key_checks=1;
 
 COMMIT;
 

--- a/t/38-mysql-producer.t
+++ b/t/38-mysql-producer.t
@@ -197,8 +197,6 @@ schema:
 EOSCHEMA
 
 my @stmts = (
-"SET foreign_key_checks=0",
-
 "DROP TABLE IF EXISTS `thing`",
 "CREATE TABLE `thing` (
   `id` unsigned int NOT NULL auto_increment,
@@ -239,8 +237,6 @@ my @stmts = (
   CONSTRAINT `fk_thing_2` FOREIGN KEY (`foo`) REFERENCES `some`.`thing2` (`id`, `foo`),
   CONSTRAINT `fk_thing_3` FOREIGN KEY (`foo2`) REFERENCES `some`.`thing2` (`id`, `foo`)
 ) ENGINE=InnoDB",
-
-"SET foreign_key_checks=1",
 
 );
 

--- a/t/64xml-to-mysql.t
+++ b/t/64xml-to-mysql.t
@@ -31,8 +31,6 @@ $sqlt = SQL::Translator->new(
 die "Can't find test schema $xmlfile" unless -e $xmlfile;
 
 my @want = (
-    q[SET foreign_key_checks=0],
-
     q[DROP TABLE IF EXISTS `Basic`],
     q[CREATE TABLE `Basic` (
   `id` integer(10) zerofill NOT NULL auto_increment,
@@ -74,8 +72,6 @@ my @want = (
     q[DROP TRIGGER IF EXISTS `bar_trigger_update`],
     q[CREATE TRIGGER `bar_trigger_update` before update ON `Basic`
   FOR EACH ROW BEGIN update modified2=timestamp(); END],
-
-    q[SET foreign_key_checks=1],
 );
 
 my $sql = $sqlt->translate(


### PR DESCRIPTION
This turns off foreign key constraint checking in MySQL not only for CREATE TABLE but also for ALTER TABLE and DROP TABLE.

This is because ALTER TABLE and DROP TABLE may also result in errors due to foreign key constraint checking.

Changed the process of changing the foreign_key_checks variable from before and after CREATE TABLE to before and after the entire diff.