### PR TITLE
Feature: Add DB comments for PG producer

### DIFF
--- a/lib/SQL/Translator/Parser/PostgreSQL.pm
+++ b/lib/SQL/Translator/Parser/PostgreSQL.pm
@@ -366,6 +366,7 @@ column_name : NAME '.' NAME
 comment_phrase : /null/i
     { $return = 'NULL' }
     | SQSTRING
+    | DOLLARSTRING
 
 field : field_comment(s?) field_name data_type field_meta(s?) field_comment(s?)
     {

--- a/lib/SQL/Translator/Producer/PostgreSQL.pm
+++ b/lib/SQL/Translator/Producer/PostgreSQL.pm
@@ -277,10 +277,8 @@ sub create_table
     if ( my $comments = $table->comments ) {
       # this follows the example in the MySQL producer, where all comments are added as
       # table comments, even though they could have originally been parsed as DDL comments
-        my $comment_ddl =
-          'CREATE COMMENT on TABLE ' 
-          . $table_name_qt 
-          . ' IS $comment$' . (join ',', @$comments) . '$comment$;';
+      # quoted via $$ string so there can be 'quotes' inside the comments
+        my $comment_ddl = "COMMENT on TABLE $table_name_qt IS \$comment\$$comments\$comment\$";
         push @comment_statements, $comment_ddl;
     }
 
@@ -298,9 +296,7 @@ sub create_table
         next unless $field_comments;
         my $field_name_qt = $generator->quote($field->name);
         my $comment_ddl =
-          'CREATE COMMENT ON COLUMN '
-          . "$table_name_qt.$field_name_qt "
-          . ' IS $comment$' . (join ',', @$field_comments) . '$comment$';
+          "COMMENT ON COLUMN $table_name_qt.$field_name_qt IS \$comment\$$field_comments\$comment\$";
         push @comment_statements, $comment_ddl;
 
     }

--- a/lib/SQL/Translator/Producer/PostgreSQL.pm
+++ b/lib/SQL/Translator/Producer/PostgreSQL.pm
@@ -296,7 +296,7 @@ sub create_table
         next unless $field_comments;
         my $field_name_qt = $generator->quote($field->name);
         my $comment_ddl =
-          "COMMENT ON COLUMN $table_name_qt.$field_name_qt IS \$comment\$$field_comments\$comment\$";
+          "COMMENT on COLUMN $table_name_qt.$field_name_qt IS \$comment\$$field_comments\$comment\$";
         push @comment_statements, $comment_ddl;
 
     }
@@ -348,6 +348,7 @@ sub create_table
         $create_statement .= join(";\n", '', map{ drop_geometry_column($_, $options) } @geometry_columns) if $options->{add_drop_table};
         $create_statement .= join(";\n", '', map{ add_geometry_column($_, $options) } @geometry_columns);
     }
+
     if (@comment_statements) {
       $create_statement .= join(";\n", '', @comment_statements);
     }

--- a/t/14postgres-parser.t
+++ b/t/14postgres-parser.t
@@ -41,6 +41,8 @@ baz $foo$,
         f_text2 text default $$$$,
         f_text3 text default $$$ $$
     );
+    COMMENT on TABLE t_test1 IS 'this is another comment on t_test1';
+    COMMENT on COLUMN t_test1.f_serial IS 'this is another comment on f_serial';
 
     create table t_test2 (
         f_id integer NOT NULL,
@@ -128,7 +130,7 @@ is( scalar @tables, 5, 'Five tables' );
 my $t1 = shift @tables;
 is( $t1->name, 't_test1', 'Table t_test1 exists' );
 
-is( $t1->comments, 'comment on t_test1', 'Table comment exists' );
+is_deeply([ $t1->comments ], [ 'comment on t_test1', 'this is another comment on t_test1' ], 'Table comment exists' );
 
 my @t1_fields = $t1->get_fields;
 is( scalar @t1_fields, 21, '21 fields in t_test1' );
@@ -140,7 +142,7 @@ is( $f1->is_nullable, 0, 'Field cannot be null' );
 is( $f1->size, 11, 'Size is "11"' );
 is( $f1->default_value, '0', 'Default value is "0"' );
 is( $f1->is_primary_key, 1, 'Field is PK' );
-is( $f1->comments, 'this is the primary key', 'Comment' );
+is_deeply( [ $f1->comments ], [ 'this is the primary key', 'this is another comment on f_serial' ], 'Comment' );
 is( $f1->is_auto_increment, 1, 'Field is auto increment' );
 
 my $f2 = shift @t1_fields;

--- a/t/14postgres-parser.t
+++ b/t/14postgres-parser.t
@@ -41,8 +41,6 @@ baz $foo$,
         f_text2 text default $$$$,
         f_text3 text default $$$ $$
     );
-    COMMENT on TABLE t_test1 IS 'this is another comment on t_test1';
-    COMMENT on COLUMN t_test1.f_serial IS 'this is another comment on f_serial';
 
     create table t_test2 (
         f_id integer NOT NULL,
@@ -130,7 +128,7 @@ is( scalar @tables, 5, 'Five tables' );
 my $t1 = shift @tables;
 is( $t1->name, 't_test1', 'Table t_test1 exists' );
 
-is_deeply([ $t1->comments ], [ 'comment on t_test1', 'this is another comment on t_test1' ], 'Table comment exists' );
+is( $t1->comments, 'comment on t_test1', 'Table comment exists' );
 
 my @t1_fields = $t1->get_fields;
 is( scalar @t1_fields, 21, '21 fields in t_test1' );
@@ -142,7 +140,7 @@ is( $f1->is_nullable, 0, 'Field cannot be null' );
 is( $f1->size, 11, 'Size is "11"' );
 is( $f1->default_value, '0', 'Default value is "0"' );
 is( $f1->is_primary_key, 1, 'Field is PK' );
-is_deeply( [ $f1->comments ], [ 'this is the primary key', 'this is another comment on f_serial' ], 'Comment' );
+is( $f1->comments, 'this is the primary key', 'Comment' );
 is( $f1->is_auto_increment, 1, 'Field is auto increment' );
 
 my $f2 = shift @t1_fields;

--- a/t/46xml-to-pg.t
+++ b/t/46xml-to-pg.t
@@ -23,6 +23,7 @@ $sqlt = SQL::Translator->new(
     no_comments => 1,
     show_warnings  => 0,
     add_drop_table => 1,
+    producer_args => { attach_comments => 1 }
 );
 
 die "Can't find test schema $xmlfile" unless -e $xmlfile;

--- a/t/46xml-to-pg.t
+++ b/t/46xml-to-pg.t
@@ -42,7 +42,6 @@ CREATE TABLE "Basic" (
   "email" character varying(500),
   "explicitnulldef" character varying,
   "explicitemptystring" character varying DEFAULT '',
-  -- Hello emptytagdef
   "emptytagdef" character varying DEFAULT '',
   "another_id" integer DEFAULT 2,
   "timest" timestamp,
@@ -51,6 +50,7 @@ CREATE TABLE "Basic" (
   CONSTRAINT "very_long_index_name_on_title_field_which_should_be_truncated_for_various_rdbms" UNIQUE ("title")
 );
 CREATE INDEX "titleindex" on "Basic" ("title");
+COMMENT on COLUMN "Basic"."emptytagdef" IS \$comment\$Hello emptytagdef\$comment\$;
 
 DROP TABLE "Another" CASCADE;
 CREATE TABLE "Another" (

--- a/t/47postgres-producer.t
+++ b/t/47postgres-producer.t
@@ -38,7 +38,8 @@ my $PRODUCER = \&SQL::Translator::Producer::PostgreSQL::create_field;
                                                  is_foreign_key => 0,
                                                  is_unique => 0 );
   $table->add_field($field);
-  my ($create, $fks) = SQL::Translator::Producer::PostgreSQL::create_table($table, { quote_table_names => q{"} });
+  my ($create, $fks) = SQL::Translator::Producer::PostgreSQL::create_table(
+    $table, { quote_table_names => q{"}, attach_comments => 1 });
   is($table->name, 'foo.bar');
 
   my $expected = <<EOESQL;

--- a/t/47postgres-producer.t
+++ b/t/47postgres-producer.t
@@ -45,18 +45,15 @@ my $PRODUCER = \&SQL::Translator::Producer::PostgreSQL::create_field;
 --
 -- Table: foo.bar
 --
-
--- Comments:
--- multi
--- line
--- single line
---
 CREATE TABLE "foo"."bar" (
-  -- multi
-  -- line
-  -- single line
   "baz" character varying(10) DEFAULT 'quux' NOT NULL
-)
+);
+COMMENT on TABLE "foo"."bar" IS \$comment\$multi
+line
+single line\$comment\$;
+COMMENT on COLUMN "foo"."bar"."baz" IS \$comment\$multi
+line
+single line\$comment\$
 EOESQL
 
   $expected =~ s/\n\z//;

--- a/t/60roundtrip.t
+++ b/t/60roundtrip.t
@@ -53,6 +53,12 @@ my $plan = [
     parser_args => {},
   },
   {
+    engine => 'PostgreSQL',
+    name => 'Postgres w/ attached comments',
+    producer_args => { attach_comments => 1 },
+    parser_args => {},
+  },
+  {
     engine => 'SQLServer',
     producer_args => {},
     parser_args => {},


### PR DESCRIPTION
Many databases support storing comments as part of the actual schema.
Postgres is one of them, just the syntax is slightly different than other RDBMS, b/c you
can't define it inline with the table definition.

This PR adds the ability to write out comments using the `COMMENT` command [documented
here](https://www.postgresql.org/docs/current/sql-comment.html). 

It follows the example of the MySQL producer and puts all comments into the schema,
including ones that were parsed as DDL only comments (line comments starting with `--`).
