### PR TITLE
Revert "Fix passing of producer args from SQL::Translator::Diff."

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Changes for SQL::Translator
 
+ * sqlt-diff: Change producer_args to sqlt_args for better self-documentation
  * Support INCLUDE on indices for Pg (producer + parser)
 
 1.62 - 2020-09-14

--- a/lib/SQL/Translator/Diff.pm
+++ b/lib/SQL/Translator/Diff.pm
@@ -272,7 +272,8 @@ sub produce_diff_sql {
         producer_type => $self->output_db,
         add_drop_table => 0,
         no_comments => 1,
-        producer_args => $self->producer_args,
+        # TODO: sort out options
+        %{ $self->producer_args }
       );
       $translator->producer_args->{no_transaction} = 1;
       my $schema = $translator->schema;

--- a/script/sqlt-diff
+++ b/script/sqlt-diff
@@ -192,7 +192,7 @@ my $result = SQL::Translator::Diff::schema_diff(
         no_batch_alters         => $no_batch_alters || 0,
         debug                   => $debug || 0,
         trace                   => $trace || 0,
-        producer_args => {
+        sqlt_args => {
             quote_table_names   => $quote || '',
             quote_field_names   => $quote || '',
         },

--- a/t/30sqlt-new-diff-mysql.t
+++ b/t/30sqlt-new-diff-mysql.t
@@ -39,7 +39,7 @@ my @out = SQL::Translator::Diff::schema_diff(
     $target_schema, 'MySQL',
     {
         no_batch_alters  => 1,
-        producer_args => { quote_identifiers => 0 }
+        sqlt_args => { quote_identifiers => 0 }
     }
 );
 
@@ -106,7 +106,7 @@ COMMIT;
 $out = SQL::Translator::Diff::schema_diff($source_schema, 'MySQL', $target_schema, 'MySQL',
     { ignore_index_names => 1,
       ignore_constraint_names => 1,
-      producer_args => { quote_identifiers => 0 },
+      sqlt_args => { quote_identifiers => 0 },
     });
 
 eq_or_diff($out, <<'## END OF DIFF', "Diff as expected", { context => 1 });
@@ -178,7 +178,7 @@ eq_or_diff($out, <<'## END OF DIFF', "No differences found", { context => 1 });
   my $field = $target_schema->get_table('employee')->get_field('employee_id');
   $field->data_type('integer');
   $field->size(0);
-  $out = SQL::Translator::Diff::schema_diff($schema, 'MySQL', $target_schema, 'MySQL', { producer_args => { quote_identifiers => 0 } } );
+  $out = SQL::Translator::Diff::schema_diff($schema, 'MySQL', $target_schema, 'MySQL', { sqlt_args => { quote_identifiers => 0 } } );
   eq_or_diff($out, <<'## END OF DIFF', "No differences found", { context => 1 });
 -- Convert schema 'create.sql' to 'create2.yml':;
 
@@ -323,7 +323,7 @@ COMMIT;
 
   # Test quoting works too.
   $out = SQL::Translator::Diff::schema_diff($s1, 'MySQL', $s2, 'MySQL',
-    { producer_args => { quote_identifiers => 1 } }
+    { sqlt_args => { quote_identifiers => 1 } }
   );
   eq_or_diff($out, <<'## END OF DIFF', "Quoting can be turned on", { context => 1 });
 -- Convert schema 'Schema 3' to 'Schema 4':;

--- a/t/30sqlt-new-diff-pgsql.t
+++ b/t/30sqlt-new-diff-pgsql.t
@@ -40,7 +40,7 @@ my $out = SQL::Translator::Diff::schema_diff(
     $target_schema,
    'PostgreSQL',
    {
-     producer_args => {
+     sqlt_args => {
          quote_identifiers => 1,
      }
    }
@@ -103,7 +103,7 @@ $out = SQL::Translator::Diff::schema_diff(
     $source_schema, 'PostgreSQL', $target_schema, 'PostgreSQL',
     { ignore_index_names => 1,
       ignore_constraint_names => 1,
-      producer_args => {
+      sqlt_args => {
          quote_identifiers => 0,
       }
     });


### PR DESCRIPTION
Reverts dbsrgits/sql-translator#117

broke the tests for SQLT-Diff, producer_args really is args for SQLT directly