### PR TITLE
Oracle producer add missing functions

### DIFF
--- a/lib/SQL/Translator/Diff.pm
+++ b/lib/SQL/Translator/Diff.pm
@@ -92,7 +92,7 @@ sub schema_diff {
     $options ||= {};
 
     my $obj = SQL::Translator::Diff->new( {
-      sqlt_args => $options,
+      %$options,
       source_schema => $source_schema,
       target_schema => $target_schema,
       output_db     => $output_db

--- a/lib/SQL/Translator/Diff.pm
+++ b/lib/SQL/Translator/Diff.pm
@@ -92,7 +92,7 @@ sub schema_diff {
     $options ||= {};
 
     my $obj = SQL::Translator::Diff->new( {
-      %$options,
+      sqlt_args => $options,
       source_schema => $source_schema,
       target_schema => $target_schema,
       output_db     => $output_db

--- a/lib/SQL/Translator/Parser/Oracle.pm
+++ b/lib/SQL/Translator/Parser/Oracle.pm
@@ -489,7 +489,17 @@ parens_name_list : '(' NAME(s /,/) ')'
 field_meta : default_val
     | column_constraint
 
-default_val  : /default/i VALUE
+default_val  : 
+    /default/i CURRENT_TIMESTAMP
+    {
+        my $val =  $item[2];
+        $return =  {
+            supertype => 'constraint',
+            type      => 'default',
+            value     => $val,
+        }
+    }
+    | /default/i VALUE
     {
         my $val =  $item[2];
         $return =  {
@@ -616,6 +626,11 @@ VALUE : /[-+]?\d*\.?\d+(?:[eE]\d+)?/
     | /null/i
     { 'NULL' }
 
+# always a scalar-ref, so that it is treated as a function and not quoted by consumers
+CURRENT_TIMESTAMP :
+      /current_timestamp(\(\))?/i { \'CURRENT_TIMESTAMP' }
+    | /now\(\)/i { \'CURRENT_TIMESTAMP' }
+    
 END_OF_GRAMMAR
 
 sub parse {

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -310,6 +310,10 @@ sub create_table {
             my $constr = create_constraint($c, $options);
             push @constraint_defs, $constr if ($constr);
             
+            my $name    = $c->name || '';
+            my @fields  = map { quote($_,$qf) } $c->fields;
+            my @rfields = map { quote($_,$qf) } $c->reference_fields;
+            
             if ( $c->type eq FOREIGN_KEY ) {
                 $name = mk_name( join('_', $table_name, $c->fields). '_fk' );
                 $name = quote($name, $qf);

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -672,15 +672,17 @@ sub create_index {
     $index_options = $index_options || '';
     my $qf = $options->{quote_field_names} || $options->{quote_identifiers};
     my $qt = $options->{quote_table_names} || $options->{quote_identifiers};
+    my $index_name = $index->name || '';
+    $index_name = $index_name ? mk_name( $index_name ) : mk_name( $index->table, $index_name || 'i' );
     return join(
         ' ',
         map { $_ || () }
         'CREATE',
         lc $index->type eq 'normal' ? 'INDEX' : $index->type . ' INDEX',
-        $index->name ? quote($index->name, $qf): '',
+        $index_name ? quote($index_name, $qf): '',
         'ON',
         quote($index->table, $qt),
-        '(' . join( ', ', map { quote($_) } $index->fields ) . ")$index_options"
+        '(' . join( ', ', map { quote($_, $qf) } $index->fields ) . ")$index_options"
     );
 }
 

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -380,18 +380,13 @@ sub create_table {
     }
 
     my $table_options = @table_options ? "\n".join("\n", @table_options) : '';
-    debug("Create is @create");
-    debug("Constraints are @constraint_defs");
-    debug("Field DEFS: " . join(', ', @field_defs));
     push @create, "CREATE TABLE $table_name_q (\n" .
             join( ",\n", map { "  $_" } @field_defs,
             ($options->{delay_constraints} ? () : @constraint_defs) ) .
             "\n)$table_options";
 
-    debug("NOW Create is @create");
     @constraint_defs = map { "ALTER TABLE $table_name_q ADD $_"  } @constraint_defs;
 
-    debug("Now constraint defs are " . join(', ', @constraint_defs));
     if ( $WARN ) {
         if ( %truncated ) {
             warn "Truncated " . keys( %truncated ) . " names:\n";

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -462,6 +462,19 @@ sub alter_field {
     return 'ALTER TABLE '.$table_name.' MODIFY ( '.join('', @$field_defs).' )';
 }
 
+sub drop_field
+{
+    my ($old_field, $options) = @_;
+
+    my $table_name = quote($old_field->table->name);
+
+    my $out = sprintf('ALTER TABLE %s DROP COLUMN %s',
+                      $table_name,
+                      quote($old_field->name));
+
+    return $out;
+}
+
 sub add_field {
     my ($new_field, $options) = @_;
 
@@ -685,8 +698,7 @@ sub create_field {
 sub alter_drop_constraint {
     my ($c, $options) = @_;
 
-    my $generator = _generator($options);
-    my $table_name = $generator->quote($c->table->name);
+    my $table_name = quote($c->table->name);
 
     my @out = ('ALTER','TABLE',$table_name,'DROP');
     if($c->type eq PRIMARY_KEY) {
@@ -694,7 +706,7 @@ sub alter_drop_constraint {
     }
     else {
         push @out, ($c->type eq FOREIGN_KEY ? $c->type : "CONSTRAINT"),
-            $generator->quote($c->name);
+            quote($c->name);
     }
     return join(' ',@out);
 }
@@ -702,7 +714,7 @@ sub alter_drop_constraint {
 sub alter_create_constraint {
     my ($index, $options) = @_;
 
-    my $table_name = _generator($options)->quote($index->table->name);
+    my $table_name = quote($index->table->name);
     return join( ' ',
                  'ALTER TABLE',
                  $table_name,

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -686,14 +686,7 @@ sub alter_drop_constraint {
     my $qi = $options->{quote_identifiers};
     my $table_name = quote($c->table->name, $qi);
 
-    my @out = ('ALTER','TABLE',$table_name,'DROP');
-    if($c->type eq PRIMARY_KEY) {
-        push @out, $c->type;
-    }
-    else {
-        push @out, ($c->type eq FOREIGN_KEY ? $c->type : "CONSTRAINT"),
-            quote($c->name, $qi);
-    }
+    my @out = ('ALTER','TABLE',$table_name,'DROP','CONSTRAINT',quote($c->name, $qi));
     return join(' ',@out);
 }
 

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -618,21 +618,6 @@ sub create_field {
         push @trigger_defs, $trigger;
     }
 
-    # Do not create a trigger to insert sysdate to all timestamp fields
-    # if ( lc $field->data_type eq 'timestamp' ) {
-    #     my $base_name = $table_name . "_". $field_name;
-    #     my $trig_name = quote(mk_name( $base_name, 'ts' ), $qt);
-    #     my $trigger =
-    #       "CREATE OR REPLACE TRIGGER $trig_name\n".
-    #       "BEFORE INSERT OR UPDATE ON $table_name_q\n".
-    #       "FOR EACH ROW WHEN (new.$field_name_q IS NULL)\n".
-    #       "BEGIN\n".
-    #       " SELECT sysdate INTO :new.$field_name_q FROM dual;\n".
-    #       "END;\n";
-
-    #       push @trigger_defs, $trigger;
-    # }
-
     push @field_defs, $field_def;
 
     if ( my $comment = $field->comments ) {

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -675,8 +675,13 @@ sub alter_drop_constraint {
     my ($c, $options) = @_;
     my $qi = $options->{quote_identifiers};
     my $table_name = quote($c->table->name, $qi);
-
-    my @out = ('ALTER','TABLE',$table_name,'DROP','CONSTRAINT',quote($c->name, $qi));
+    my @out = ('ALTER','TABLE',$table_name,'DROP',);
+    if ($c->name) {
+        push @out, ('CONSTRAINT',quote($c->name, $qi));
+    }
+    elsif ($c->type eq PRIMARY_KEY) {
+        push @out, 'PRIMARY KEY';
+    }
     return join(' ',@out);
 }
 

--- a/lib/SQL/Translator/Producer/Oracle.pm
+++ b/lib/SQL/Translator/Producer/Oracle.pm
@@ -396,8 +396,13 @@ sub alter_field {
       create_field($to_field, $options, {});
 
     # Fix ORA-01442
-    if ($to_field->is_nullable && !$from_field->is_nullable) {
-        die 'Cannot remove NOT NULL from table field';
+    if (!$from_field->is_nullable && $to_field->is_nullable) {
+        if ($from_field->data_type =~ /text/) {
+            die 'Cannot alter CLOB field in this way';
+        }
+        else {
+            @$field_defs = map { $_ .= ' NULL' } @$field_defs;
+        }
     } elsif (!$from_field->is_nullable && !$to_field->is_nullable) {
         @$field_defs = map { s/ NOT NULL//; $_} @$field_defs;
     }

--- a/t/15oracle-parser.t
+++ b/t/15oracle-parser.t
@@ -7,7 +7,7 @@ use SQL::Translator;
 use SQL::Translator::Schema::Constants;
 use Test::SQL::Translator qw(maybe_plan);
 
-maybe_plan(99, 'SQL::Translator::Parser::Oracle');
+maybe_plan(103, 'SQL::Translator::Parser::Oracle');
 SQL::Translator::Parser::Oracle->import('parse');
 
 my $t   = SQL::Translator->new( trace => 0 );
@@ -34,6 +34,7 @@ my $sql = q[
         trait_symbol            VARCHAR2(100 BYTE)   NOT NULL,
         trait_name              VARCHAR2(200 CHAR)   NOT NULL,
         qtl_trait_category_id   NUMBER(11)      NOT NULL,
+        trait_date              DATE            DEFAULT CURRENT_TIMESTAMP NOT NULL,
         UNIQUE ( trait_symbol ),
         UNIQUE ( trait_name ),
         FOREIGN KEY ( qtl_trait_category_id ) REFERENCES qtl_trait_category
@@ -179,7 +180,7 @@ is( $t2->name, 'qtl_trait', 'Table "qtl_trait" exists' );
 is( $t2->comments, 'foo bar comment', 'Comment "foo bar" exists' );
 
 my @t2_fields = $t2->get_fields;
-is( scalar @t2_fields, 4, '4 fields in table' );
+is( scalar @t2_fields, 5, '5 fields in table' );
 
 my $t2_f1 = shift @t2_fields;
 is( $t2_f1->name, 'qtl_trait_id', 'First field is "qtl_trait_id"' );
@@ -216,6 +217,16 @@ is( $f4_fk->reference_table, 'qtl_trait_category',
     'FK references table "qtl_trait_category"' );
 is( join(',', $f4_fk->reference_fields), 'qtl_trait_category_id',
     'FK references field "qtl_trait_category_id"' );
+
+my $t2_f5 = shift @t2_fields;
+is( $t2_f5->name, 'trait_date', 'Fifth field is "trait_date"');
+is( $t2_f5->data_type, 'DATE', 'Field is a timestamp' );
+is( $t2_f5->is_nullable, 0, 'Field cannot be null' );
+is_deeply(
+    $t2_f5->default_value,
+    \'CURRENT_TIMESTAMP',
+    'Field has correct default value'
+);
 
 my @t2_constraints = $t2->get_constraints;
 is( scalar @t2_constraints, 4, '4 constraints on table' );

--- a/t/51-xml-to-oracle.t
+++ b/t/51-xml-to-oracle.t
@@ -39,7 +39,7 @@ my $sql_string = $sqlt->translate(
     to       => 'Oracle',
     filename => $xmlfile,
 ) or die $sqlt->error;
-
+warn "SQL: " . join("\n", @sql) . "\n";
 my $want = [
 'DROP TABLE Basic CASCADE CONSTRAINTS',
           'DROP SEQUENCE sq_Basic_id',
@@ -58,19 +58,19 @@ my $want = [
   CONSTRAINT u_Basic_emailuniqueindex UNIQUE (email),
   CONSTRAINT u_Basic_very_long_index_name_o UNIQUE (title)
 )',
-          'DROP TABLE Another CASCADE CONSTRAINTS',
-          'DROP SEQUENCE sq_Another_id',
-          'CREATE SEQUENCE sq_Another_id',
-          'CREATE TABLE Another (
+'DROP TABLE Another CASCADE CONSTRAINTS',
+'DROP SEQUENCE sq_Another_id',
+'CREATE SEQUENCE sq_Another_id',
+'CREATE TABLE Another (
   id number(10) NOT NULL,
   num number(10,2),
   PRIMARY KEY (id)
 )',
 'DROP VIEW email_list',
-          'CREATE VIEW email_list AS
+'CREATE VIEW email_list AS
 SELECT email FROM Basic WHERE (email IS NOT NULL)',
-          'ALTER TABLE Basic ADD CONSTRAINT Basic_another_id_fk FOREIGN KEY (another_id) REFERENCES Another (id)',
-          'CREATE OR REPLACE TRIGGER ai_Basic_id
+'ALTER TABLE Basic ADD CONSTRAINT Basic_another_id_fk FOREIGN KEY (another_id) REFERENCES Another (id)',
+'CREATE OR REPLACE TRIGGER ai_Basic_id
 BEFORE INSERT ON Basic
 FOR EACH ROW WHEN (
  new.id IS NULL OR new.id = 0
@@ -81,14 +81,7 @@ BEGIN
  FROM dual;
 END;
 ',
-          'CREATE OR REPLACE TRIGGER ts_Basic_timest
-BEFORE INSERT OR UPDATE ON Basic
-FOR EACH ROW WHEN (new.timest IS NULL)
-BEGIN
- SELECT sysdate INTO :new.timest FROM dual;
-END;
-',
-          'CREATE OR REPLACE TRIGGER ai_Another_id
+'CREATE OR REPLACE TRIGGER ai_Another_id
 BEFORE INSERT ON Another
 FOR EACH ROW WHEN (
  new.id IS NULL OR new.id = 0
@@ -99,7 +92,7 @@ BEGIN
  FROM dual;
 END;
 ',
-'CREATE INDEX titleindex on Basic (title)'];
+'CREATE INDEX titleindex ON Basic (title)'];
 
 is_deeply(\@sql, $want, 'Got correct Oracle statements in list context');
 
@@ -143,7 +136,7 @@ SELECT email FROM Basic WHERE (email IS NOT NULL);
 
 ALTER TABLE Basic ADD CONSTRAINT Basic_another_id_fk01 FOREIGN KEY (another_id) REFERENCES Another (id);
 
-CREATE INDEX titleindex01 on Basic (title);
+CREATE INDEX titleindex ON Basic (title);
 
 CREATE OR REPLACE TRIGGER ai_Basic_id01
 BEFORE INSERT ON Basic
@@ -154,14 +147,6 @@ BEGIN
  SELECT sq_Basic_id01.nextval
  INTO :new.id
  FROM dual;
-END;
-/
-
-CREATE OR REPLACE TRIGGER ts_Basic_timest01
-BEFORE INSERT OR UPDATE ON Basic
-FOR EACH ROW WHEN (new.timest IS NULL)
-BEGIN
- SELECT sysdate INTO :new.timest FROM dual;
 END;
 /
 

--- a/t/51-xml-to-oracle.t
+++ b/t/51-xml-to-oracle.t
@@ -39,7 +39,7 @@ my $sql_string = $sqlt->translate(
     to       => 'Oracle',
     filename => $xmlfile,
 ) or die $sqlt->error;
-warn "SQL: " . join("\n", @sql) . "\n";
+
 my $want = [
 'DROP TABLE Basic CASCADE CONSTRAINTS',
           'DROP SEQUENCE sq_Basic_id',
@@ -136,7 +136,7 @@ SELECT email FROM Basic WHERE (email IS NOT NULL);
 
 ALTER TABLE Basic ADD CONSTRAINT Basic_another_id_fk01 FOREIGN KEY (another_id) REFERENCES Another (id);
 
-CREATE INDEX titleindex ON Basic (title);
+CREATE INDEX titleindex01 ON Basic (title);
 
 CREATE OR REPLACE TRIGGER ai_Basic_id01
 BEFORE INSERT ON Basic

--- a/t/51-xml-to-oracle_quoted.t
+++ b/t/51-xml-to-oracle_quoted.t
@@ -42,9 +42,9 @@ my $sql_string = $sqlt->translate(
 
 my $want = [
 'DROP TABLE "Basic" CASCADE CONSTRAINTS',
-          'DROP SEQUENCE "sq_Basic_id"',
-          'CREATE SEQUENCE "sq_Basic_id"',
-          'CREATE TABLE "Basic" (
+'DROP SEQUENCE "sq_Basic_id"',
+'CREATE SEQUENCE "sq_Basic_id"',
+'CREATE TABLE "Basic" (
   "id" number(10) NOT NULL,
   "title" varchar2(100) DEFAULT \'hello\' NOT NULL,
   "description" clob DEFAULT \'\',
@@ -58,19 +58,19 @@ my $want = [
   CONSTRAINT "u_Basic_emailuniqueindex" UNIQUE ("email"),
   CONSTRAINT "u_Basic_very_long_index_name_o" UNIQUE ("title")
 )',
-          'DROP TABLE "Another" CASCADE CONSTRAINTS',
-          'DROP SEQUENCE "sq_Another_id"',
-          'CREATE SEQUENCE "sq_Another_id"',
-          'CREATE TABLE "Another" (
+'DROP TABLE "Another" CASCADE CONSTRAINTS',
+'DROP SEQUENCE "sq_Another_id"',
+'CREATE SEQUENCE "sq_Another_id"',
+'CREATE TABLE "Another" (
   "id" number(10) NOT NULL,
   "num" number(10,2),
   PRIMARY KEY ("id")
 )',
 'DROP VIEW "email_list"',
-          'CREATE VIEW "email_list" AS
+'CREATE VIEW "email_list" AS
 SELECT email FROM Basic WHERE (email IS NOT NULL)',
-          'ALTER TABLE "Basic" ADD CONSTRAINT "Basic_another_id_fk" FOREIGN KEY ("another_id") REFERENCES "Another" ("id")',
-          'CREATE OR REPLACE TRIGGER "ai_Basic_id"
+'ALTER TABLE "Basic" ADD CONSTRAINT "Basic_another_id_fk" FOREIGN KEY ("another_id") REFERENCES "Another" ("id")',
+'CREATE OR REPLACE TRIGGER "ai_Basic_id"
 BEFORE INSERT ON "Basic"
 FOR EACH ROW WHEN (
  new."id" IS NULL OR new."id" = 0
@@ -81,14 +81,7 @@ BEGIN
  FROM dual;
 END;
 ',
-          'CREATE OR REPLACE TRIGGER "ts_Basic_timest"
-BEFORE INSERT OR UPDATE ON "Basic"
-FOR EACH ROW WHEN (new."timest" IS NULL)
-BEGIN
- SELECT sysdate INTO :new."timest" FROM dual;
-END;
-',
-          'CREATE OR REPLACE TRIGGER "ai_Another_id"
+'CREATE OR REPLACE TRIGGER "ai_Another_id"
 BEFORE INSERT ON "Another"
 FOR EACH ROW WHEN (
  new."id" IS NULL OR new."id" = 0
@@ -99,7 +92,7 @@ BEGIN
  FROM dual;
 END;
 ',
-'CREATE INDEX "titleindex" on "Basic" ("title")'];
+'CREATE INDEX "titleindex" ON "Basic" ("title")'];
 
 is_deeply(\@sql, $want, 'Got correct Oracle statements in list context');
 
@@ -143,7 +136,7 @@ SELECT email FROM Basic WHERE (email IS NOT NULL);
 
 ALTER TABLE "Basic" ADD CONSTRAINT "Basic_another_id_fk01" FOREIGN KEY ("another_id") REFERENCES "Another" ("id");
 
-CREATE INDEX "titleindex01" on "Basic" ("title");
+CREATE INDEX "titleindex01" ON "Basic" ("title");
 
 CREATE OR REPLACE TRIGGER "ai_Basic_id01"
 BEFORE INSERT ON "Basic"
@@ -154,14 +147,6 @@ BEGIN
  SELECT "sq_Basic_id01".nextval
  INTO :new."id"
  FROM dual;
-END;
-/
-
-CREATE OR REPLACE TRIGGER "ts_Basic_timest01"
-BEFORE INSERT OR UPDATE ON "Basic"
-FOR EACH ROW WHEN (new."timest" IS NULL)
-BEGIN
- SELECT sysdate INTO :new."timest" FROM dual;
 END;
 /
 

--- a/t/54-oracle-alter-constraint.t
+++ b/t/54-oracle-alter-constraint.t
@@ -54,6 +54,6 @@ like($diff, '/DROP CONSTRAINT other_check/', 'DROP constraint other_check genera
 
 like($diff, '/ADD CONSTRAINT other_check CHECK \(other BETWEEN 100 and 99999\)/', 'ADD check constraint generated');
 
-like($diff, '/ALTER TABLE supplier CONSTRAINT fk_customer/', 'DROP Foreign key constraint generated');
+like($diff, '/ALTER TABLE supplier DROP CONSTRAINT fk_customer/', 'DROP Foreign key constraint generated');
 
 like($diff, '/DROP TABLE customer/', 'DROP TABLE customer generated');

--- a/t/54-oracle-alter-constraint.t
+++ b/t/54-oracle-alter-constraint.t
@@ -54,6 +54,6 @@ like($diff, '/DROP CONSTRAINT other_check/', 'DROP constraint other_check genera
 
 like($diff, '/ADD CONSTRAINT other_check CHECK \(other BETWEEN 100 and 99999\)/', 'ADD check constraint generated');
 
-like($diff, '/ALTER TABLE supplier DROP FOREIGN KEY fk_customer/', 'DROP Foreign key constraint generated');
+like($diff, '/ALTER TABLE supplier CONSTRAINT fk_customer/', 'DROP Foreign key constraint generated');
 
 like($diff, '/DROP TABLE customer/', 'DROP TABLE customer generated');

--- a/t/54-oracle-alter-constraint.t
+++ b/t/54-oracle-alter-constraint.t
@@ -9,7 +9,7 @@ use SQL::Translator;
 use SQL::Translator::Diff;
 
 BEGIN {
-    maybe_plan(4, 'SQL::Translator::Parser::YAML',
+    maybe_plan(6, 'SQL::Translator::Parser::YAML',
                   'SQL::Translator::Producer::Oracle');
 }
 
@@ -50,6 +50,10 @@ ok($diff, 'Diff generated.');
 
 like($diff, '/ALTER TABLE d_operator DROP CONSTRAINT foo_unique/', 'DROP constraint foo_unique generated');
 
-like($diff, '/ALTER TABLE d_operator DROP CONSTRAINT other_check/', 'DROP constraint other_check generated');
+like($diff, '/DROP CONSTRAINT other_check/', 'DROP constraint other_check generated');
 
 like($diff, '/ADD CONSTRAINT other_check CHECK \(other BETWEEN 100 and 99999\)/', 'ADD check constraint generated');
+
+like($diff, '/ALTER TABLE supplier DROP FOREIGN KEY fk_customer/', 'DROP Foreign key constraint generated');
+
+like($diff, '/DROP TABLE customer/', 'DROP TABLE customer generated');

--- a/t/54-oracle-alter-field.t
+++ b/t/54-oracle-alter-field.t
@@ -47,7 +47,7 @@ my $d = SQL::Translator::Diff->new
 my $diff = $d->compute_differences->produce_diff_sql || die $d->error;
 
 ok($diff, 'Diff generated.');
-like($diff, '/ALTER TABLE d_operator MODIFY \( name nvarchar2\(10\) \)/',
+like($diff, '/ALTER TABLE d_operator MODIFY \( name nvarchar2\(10\) NULL \)/',
      'Alter table generated.');
 like($diff, '/ALTER TABLE d_operator MODIFY \( other nvarchar2\(10\) NOT NULL \)/',
      'Alter table generated.');

--- a/t/54-oracle-sql-diff.t
+++ b/t/54-oracle-sql-diff.t
@@ -9,7 +9,7 @@ use SQL::Translator;
 use SQL::Translator::Diff;
 
 BEGIN {
-    maybe_plan(10, 'SQL::Translator::Producer::Oracle');
+    maybe_plan(11, 'SQL::Translator::Producer::Oracle');
 }
 
 my $schema1 = $Bin.'/data/oracle/schema-1.5.sql';

--- a/t/54-oracle-sql-diff.t
+++ b/t/54-oracle-sql-diff.t
@@ -48,6 +48,8 @@ ok($diff, 'Diff generated.');
 
 like($diff, '/CREATE TABLE t_group/', 'CREATE TABLE t_group generated');
 
+like($diff, '/ALTER TABLE t_category DROP PRIMARY KEY/', 'Drop PRIMARY KEY generated');
+
 like($diff, '/ALTER TABLE t_category DROP CONSTRAINT t_category_display_name/', 'DROP constraint t_category_display_name generated');
 
 like($diff, '/ALTER TABLE t_user_groups DROP CONSTRAINT t_user_groups_group_id_fk/', 'DROP FOREIGN KEY constraint generated');

--- a/t/54-oracle-sql-diff.t
+++ b/t/54-oracle-sql-diff.t
@@ -50,7 +50,7 @@ like($diff, '/CREATE TABLE t_group/', 'CREATE TABLE t_group generated');
 
 like($diff, '/ALTER TABLE t_category DROP CONSTRAINT t_category_display_name/', 'DROP constraint t_category_display_name generated');
 
-like($diff, '/ALTER TABLE t_user_groups DROP FOREIGN KEY t_user_groups_group_id_fk/', 'DROP FOREIGN KEY constraint generated');
+like($diff, '/ALTER TABLE t_user_groups DROP CONSTRAINT t_user_groups_group_id_fk/', 'DROP FOREIGN KEY constraint generated');
 
 like($diff, '/DROP INDEX t_alert_roles_idx_alert_id/', 'DROP INDEX generated');
 
@@ -60,6 +60,6 @@ like($diff, '/CREATE INDEX t_user_groups_idx_user_id ON t_user_groups \(user_id\
 
 like($diff, '/ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_group_id_fk FOREIGN KEY \(group_id\) REFERENCES t_group \(group_id\) ON DELETE CASCADE/', 'ADD FOREIGN KEY constraint generated');
 
-like($diff, '/ALTER TABLE t_population_group DROP FOREIGN KEY t_population_group_group_role_fk/', 'DROP FOREIGN KEY before drop table generated');
+like($diff, '/ALTER TABLE t_population_group DROP CONSTRAINT t_population_group_group_role_fk/', 'DROP FOREIGN KEY before drop table generated');
 
 like($diff, '/DROP TABLE t_population_group/', 'DROP TABLE generated');

--- a/t/54-oracle-sql-diff.t
+++ b/t/54-oracle-sql-diff.t
@@ -9,7 +9,7 @@ use SQL::Translator;
 use SQL::Translator::Diff;
 
 BEGIN {
-    maybe_plan(6, 'SQL::Translator::Producer::Oracle');
+    maybe_plan(10, 'SQL::Translator::Producer::Oracle');
 }
 
 my $schema1 = $Bin.'/data/oracle/schema-1.5.sql';
@@ -37,30 +37,29 @@ $t->parser->($t,$sql2);
 my $d = SQL::Translator::Diff->new
   ({
     output_db => 'Oracle',
-    target_db => 'Oracle',
     source_schema => $s->schema,
     target_schema => $t->schema,
-    sqlt_args => {quote_identifiers => 1}
+    sqlt_args => {quote_identifiers => 0}
    });
-
 
 my $diff = $d->compute_differences->produce_diff_sql || die $d->error;
 
 ok($diff, 'Diff generated.');
 
-warn "The diff is: " . Dumper($diff);
-
 like($diff, '/CREATE TABLE t_group/', 'CREATE TABLE t_group generated');
 
-like($diff, '/ALTER TABLE t_category DROP CONSTRAINT t_category_display_name/', 'DROP constraint display_name generated');
+like($diff, '/ALTER TABLE t_category DROP CONSTRAINT t_category_display_name/', 'DROP constraint t_category_display_name generated');
+
+like($diff, '/ALTER TABLE t_user_groups DROP FOREIGN KEY t_user_groups_group_id_fk/', 'DROP FOREIGN KEY constraint generated');
+
+like($diff, '/DROP INDEX t_alert_roles_idx_alert_id/', 'DROP INDEX generated');
 
 like($diff, '/ALTER TABLE t_message MODIFY \( alert_id number\(11\) \)/', 'MODIFY alert_id generated');
 
 like($diff, '/CREATE INDEX t_user_groups_idx_user_id ON t_user_groups \(user_id\)/', 'CREATE INDEX generated');
-# like($diff, '/ALTER TABLE t_category_defaults DROP FOREIGN KEY t_category_defaults_user_id/', 'DROP FOREIGN KEY constraint generated');
 
-# like($diff, '/ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_group_id_fk FOREIGN KEY \(group_id\) REFERENCES t_group \(group_id\) ON DELETE CASCADE/', 'ADD FOREIGN KEY constraint generated');
+like($diff, '/ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_group_id_fk FOREIGN KEY \(group_id\) REFERENCES t_group \(group_id\) ON DELETE CASCADE/', 'ADD FOREIGN KEY constraint generated');
 
-# like($diff, '/ADD CONSTRAINT other_check CHECK \(other BETWEEN 100 and 99999\)/', 'ADD check constraint generated');
+like($diff, '/ALTER TABLE t_population_group DROP FOREIGN KEY t_population_group_group_role_fk/', 'DROP FOREIGN KEY before drop table generated');
 
-# like($diff, '/DROP TABLE customer/', 'DROP TABLE customer generated');
+like($diff, '/DROP TABLE t_population_group/', 'DROP TABLE generated');

--- a/t/54-oracle-sql-diff.t
+++ b/t/54-oracle-sql-diff.t
@@ -1,0 +1,66 @@
+#!/usr/bin/perl
+
+use FindBin qw/$Bin/;
+use Test::More;
+use Test::SQL::Translator;
+use Test::Exception;
+use Data::Dumper;
+use SQL::Translator;
+use SQL::Translator::Diff;
+
+BEGIN {
+    maybe_plan(6, 'SQL::Translator::Producer::Oracle');
+}
+
+my $schema1 = $Bin.'/data/oracle/schema-1.5.sql';
+my $schema2 = $Bin.'/data/oracle/schema-1.6.sql';
+
+open my $io1, '<', $schema1 or die $!;
+open my $io2, '<', $schema2 or die $!;
+
+my ($yaml1, $yaml2);
+{
+    local $/ = undef;
+    $sql1 = <$io1>;
+    $sql2 = <$io2>;
+};
+
+close $io1;
+close $io2;
+
+my $s = SQL::Translator->new(from => 'Oracle');
+$s->parser->($s,$sql1);
+
+my $t = SQL::Translator->new(from => 'Oracle', debug => 1);
+$t->parser->($t,$sql2);
+
+my $d = SQL::Translator::Diff->new
+  ({
+    output_db => 'Oracle',
+    target_db => 'Oracle',
+    source_schema => $s->schema,
+    target_schema => $t->schema,
+    sqlt_args => {quote_identifiers => 1}
+   });
+
+
+my $diff = $d->compute_differences->produce_diff_sql || die $d->error;
+
+ok($diff, 'Diff generated.');
+
+warn "The diff is: " . Dumper($diff);
+
+like($diff, '/CREATE TABLE t_group/', 'CREATE TABLE t_group generated');
+
+like($diff, '/ALTER TABLE t_category DROP CONSTRAINT t_category_display_name/', 'DROP constraint display_name generated');
+
+like($diff, '/ALTER TABLE t_message MODIFY \( alert_id number\(11\) \)/', 'MODIFY alert_id generated');
+
+like($diff, '/CREATE INDEX t_user_groups_idx_user_id ON t_user_groups \(user_id\)/', 'CREATE INDEX generated');
+# like($diff, '/ALTER TABLE t_category_defaults DROP FOREIGN KEY t_category_defaults_user_id/', 'DROP FOREIGN KEY constraint generated');
+
+# like($diff, '/ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_group_id_fk FOREIGN KEY \(group_id\) REFERENCES t_group \(group_id\) ON DELETE CASCADE/', 'ADD FOREIGN KEY constraint generated');
+
+# like($diff, '/ADD CONSTRAINT other_check CHECK \(other BETWEEN 100 and 99999\)/', 'ADD check constraint generated');
+
+# like($diff, '/DROP TABLE customer/', 'DROP TABLE customer generated');

--- a/t/55-oracle-add-drop-field.t
+++ b/t/55-oracle-add-drop-field.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+
+use FindBin qw/$Bin/;
+use Test::More;
+use Test::SQL::Translator;
+use Test::Exception;
+use Data::Dumper;
+use SQL::Translator;
+use SQL::Translator::Diff;
+
+BEGIN {
+    maybe_plan(3, 'SQL::Translator::Parser::YAML',
+                  'SQL::Translator::Producer::Oracle');
+}
+
+my $schema1 = $Bin.'/data/oracle/schema_diff_b.yaml';
+my $schema2 = $Bin.'/data/oracle/schema_diff_c.yaml';
+
+open my $io1, '<', $schema1 or die $!;
+open my $io2, '<', $schema2 or die $!;
+
+my ($yaml1, $yaml2);
+{
+    local $/ = undef;
+    $yaml1 = <$io1>;
+    $yaml2 = <$io2>;
+};
+
+close $io1;
+close $io2;
+
+my $s = SQL::Translator->new(from => 'YAML');
+$s->parser->($s,$yaml1);
+
+my $t = SQL::Translator->new(from => 'YAML');
+$t->parser->($t,$yaml2);
+
+my $d = SQL::Translator::Diff->new
+  ({
+    output_db => 'Oracle',
+    source_schema => $s->schema,
+    target_schema => $t->schema,
+   });
+
+
+my $diff = $d->compute_differences->produce_diff_sql || die $d->error;
+
+ok($diff, 'Diff generated.');
+
+like($diff, '/ALTER TABLE d_operator DROP COLUMN bar/', 'DROP column generated.');
+like($diff, '/ALTER TABLE d_operator ADD \( foo nvarchar2\(10\) NOT NULL \)/', 'ADD column generated.');

--- a/t/55-oracle-producer.t
+++ b/t/55-oracle-producer.t
@@ -69,12 +69,17 @@ use SQL::Translator::Producer::Oracle;
         type             => FOREIGN_KEY,
     );
 
-    my ($table1_def, $trigger1_def,
+    my ($table1_def, $fk1_def, $trigger1_def,
         $index1_def, $constraint1_def
     ) = SQL::Translator::Producer::Oracle::create_table($table1);
 
-    like($table1_def->[1], '/CONSTRAINT table1_fk_col1_fk_col2_fk FOREIGN KEY \(fk_col1, fk_col2\) REFERENCES table2 \(fk_col1, fk_col2\)/', 'correct "CONSTRAINT" SQL');
-
+    is_deeply(
+        $fk1_def,
+        [   'ALTER TABLE table1 ADD CONSTRAINT table1_fk_col1_fk_col2_fk FOREIGN KEY (fk_col1, fk_col2) REFERENCES table2 (fk_col1, fk_col2)'
+        ],
+        'correct "CREATE CONSTRAINT" SQL'
+    );
+    
     my $materialized_view = SQL::Translator::Schema::View->new(
         name    => 'matview',
         sql     => 'SELECT id, name FROM table3',

--- a/t/55-oracle-producer.t
+++ b/t/55-oracle-producer.t
@@ -69,16 +69,11 @@ use SQL::Translator::Producer::Oracle;
         type             => FOREIGN_KEY,
     );
 
-    my ($table1_def, $fk1_def, $trigger1_def,
+    my ($table1_def, $trigger1_def,
         $index1_def, $constraint1_def
     ) = SQL::Translator::Producer::Oracle::create_table($table1);
 
-    is_deeply(
-        $fk1_def,
-        [   'ALTER TABLE table1 ADD CONSTRAINT table1_fk_col1_fk_col2_fk FOREIGN KEY (fk_col1, fk_col2) REFERENCES table2 (fk_col1, fk_col2)'
-        ],
-        'correct "CREATE CONSTRAINT" SQL'
-    );
+    like($table1_def->[1], '/CONSTRAINT table1_fk_col1_fk_col2_fk FOREIGN KEY \(fk_col1, fk_col2\) REFERENCES table2 \(fk_col1, fk_col2\)/', 'correct "CONSTRAINT" SQL');
 
     my $materialized_view = SQL::Translator::Schema::View->new(
         name    => 'matview',

--- a/t/data/oracle/schema-1.5.sql
+++ b/t/data/oracle/schema-1.5.sql
@@ -1,0 +1,211 @@
+CREATE TABLE t_category (
+  category_id number(11) NOT NULL,
+  display_name varchar2(256) NOT NULL,
+  description varchar2(4000) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (category_id),
+  CONSTRAINT t_category_display_name UNIQUE (display_name)
+);
+
+
+CREATE SEQUENCE sq_t_message_message_id;
+
+CREATE TABLE t_message (
+  message_id number(11) NOT NULL,
+  alert_id number(45) NOT NULL,
+  from_address varchar2(256) NOT NULL,
+  recipient nvarchar2(64) NOT NULL,
+  subject_line varchar2(512) NOT NULL,
+  body_text clob NOT NULL,
+  body_html clob NOT NULL,
+  short_body varchar2(160) NOT NULL,
+  template_id number(11) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (message_id)
+);
+
+
+CREATE TABLE t_user (
+  user_id varchar2(32) NOT NULL,
+  name varchar2(256),
+  last4_pid varchar2(4) NOT NULL,
+  pidm number(11) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  mobile_phone varchar2(11),
+  mobile_phone_source varchar2(64),
+  reason_for_change varchar2(128),
+  im_id varchar2(512),
+  opt_in date,
+  opt_in_confirm date,
+  mobile_phone_2 varchar2(11),
+  PRIMARY KEY (user_id),
+  CONSTRAINT t_user_pidm UNIQUE (pidm)
+);
+
+
+CREATE SEQUENCE sq_t_population_group_group_;
+
+CREATE TABLE t_population_group (
+  group_id number(11) NOT NULL,
+  group_name varchar2(256) NOT NULL,
+  group_description varchar2(256) NOT NULL,
+  group_role number(11),
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  group_type varchar2(256),
+  group_sql clob NOT NULL,
+  active number(1) NOT NULL,
+  source varchar2(256) NOT NULL,
+  private number(1) NOT NULL,
+  fpm_bldg_no varchar2(11) NOT NULL,
+  PRIMARY KEY (group_id)
+);
+
+
+CREATE SEQUENCE sq_t_role_role_id;
+
+CREATE TABLE t_role (
+  role_id number(11) NOT NULL,
+  role_name varchar2(64) NOT NULL,
+  role_desc varchar2(128) NOT NULL,
+  PRIMARY KEY (role_id)
+);
+
+
+CREATE SEQUENCE sq_t_alert_alert_id;
+
+CREATE TABLE t_alert (
+  alert_id number(11) NOT NULL,
+  category number(11) NOT NULL,
+  title varchar2(64) NOT NULL,
+  allow_email_opt_out number(1) NOT NULL,
+  enabled number(1) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (alert_id)
+);
+
+
+CREATE TABLE t_user_groups (
+  user_id varchar2(32) NOT NULL,
+  group_id number(11) NOT NULL,
+  PRIMARY KEY (user_id, group_id)
+);
+
+
+CREATE TABLE t_user_roles (
+  user_id varchar2(32) NOT NULL,
+  role_id number(11) NOT NULL,
+  PRIMARY KEY (user_id, role_id)
+);
+
+
+CREATE TABLE t_category_defaults (
+  category_id number(11) NOT NULL,
+  user_id varchar2(32) NOT NULL,
+  default_email number(1) NOT NULL,
+  default_sms number(1) NOT NULL,
+  default_push number(1) NOT NULL,
+  default_im number(1) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (category_id, user_id)
+);
+
+
+CREATE TABLE t_alert_roles (
+  alert_id number(11) NOT NULL,
+  role_id number(11) NOT NULL,
+  PRIMARY KEY (alert_id, role_id)
+);
+
+ALTER TABLE t_alert ADD CONSTRAINT t_alert_category_fk FOREIGN KEY (category) REFERENCES t_category (category_id);
+
+ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_group_id_fk FOREIGN KEY (group_id) REFERENCES t_population_group (group_id) ON DELETE CASCADE;
+
+ALTER TABLE t_user_roles ADD CONSTRAINT t_user_roles_role_id_fk FOREIGN KEY (role_id) REFERENCES t_role (role_id) ON DELETE CASCADE;
+
+ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_category FOREIGN KEY (category_id) REFERENCES t_category (category_id);
+
+ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_user_id FOREIGN KEY (user_id) REFERENCES t_user (user_id);
+
+ALTER TABLE t_alert_roles ADD CONSTRAINT t_alert_roles_alert_id_fk FOREIGN KEY (alert_id) REFERENCES t_alert (alert_id) ON DELETE CASCADE;
+
+ALTER TABLE t_alert_roles ADD CONSTRAINT t_alert_roles_role_id_fk FOREIGN KEY (role_id) REFERENCES t_role (role_id);
+
+ALTER TABLE t_population_group ADD CONSTRAINT t_population_group_group_role_fk FOREIGN KEY (group_role) REFERENCES t_role (role_id);
+
+CREATE INDEX t_alert_idx_category on t_alert (category);
+
+CREATE INDEX t_user_groups_idx_group_id on t_user_groups (group_id);
+
+CREATE INDEX t_user_roles_idx_role_id on t_user_roles (role_id);
+
+CREATE INDEX t_category_defaults_idx_cate on t_category_defaults (category_id);
+
+CREATE INDEX t_category_defaults_idx_acce on t_category_defaults (user_id);
+
+CREATE INDEX t_alert_roles_idx_alert_id on t_alert_roles (alert_id);
+
+CREATE INDEX t_alert_roles_idx_role_id on t_alert_roles (role_id);
+
+CREATE OR REPLACE TRIGGER ai_t_message_message_id
+BEFORE INSERT ON t_message
+FOR EACH ROW WHEN (
+ new.message_id IS NULL OR new.message_id = 0
+)
+BEGIN
+ SELECT sq_t_message_message_id.nextval
+ INTO :new.message_id
+ FROM dual;
+END;
+/
+
+CREATE OR REPLACE TRIGGER ai_t_population_group_group_
+BEFORE INSERT ON t_population_group
+FOR EACH ROW WHEN (
+ new.group_id IS NULL OR new.group_id = 0
+)
+BEGIN
+ SELECT sq_t_population_group_group_.nextval
+ INTO :new.group_id
+ FROM dual;
+END;
+/
+
+CREATE OR REPLACE TRIGGER ai_t_role_role_id
+BEFORE INSERT ON t_role
+FOR EACH ROW WHEN (
+ new.role_id IS NULL OR new.role_id = 0
+)
+BEGIN
+ SELECT sq_t_role_role_id.nextval
+ INTO :new.role_id
+ FROM dual;
+END;
+/
+
+CREATE OR REPLACE TRIGGER ai_t_alert_alert_id
+BEFORE INSERT ON t_alert
+FOR EACH ROW WHEN (
+ new.alert_id IS NULL OR new.alert_id = 0
+)
+BEGIN
+ SELECT sq_t_alert_alert_id.nextval
+ INTO :new.alert_id
+ FROM dual;
+END;
+/

--- a/t/data/oracle/schema-1.5.sql
+++ b/t/data/oracle/schema-1.5.sql
@@ -152,6 +152,8 @@ CREATE INDEX t_alert_idx_category on t_alert (category);
 
 CREATE INDEX t_user_groups_idx_group_id on t_user_groups (group_id);
 
+CREATE INDEX t_user_roles_idx_user_id on t_user_roles (user_id);
+
 CREATE INDEX t_user_roles_idx_role_id on t_user_roles (role_id);
 
 CREATE INDEX t_category_defaults_idx_cate on t_category_defaults (category_id);

--- a/t/data/oracle/schema-1.6.sql
+++ b/t/data/oracle/schema-1.6.sql
@@ -1,0 +1,207 @@
+CREATE TABLE t_category (
+  category_id number(11) NOT NULL,
+  display_name varchar2(256) NOT NULL,
+  description varchar2(4000) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (category_id)
+);
+
+CREATE SEQUENCE sq_t_group_group_id;
+
+CREATE TABLE t_group (
+  group_id number(11) NOT NULL,
+  group_name varchar2(256) NOT NULL,
+  group_description varchar2(256) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  group_type varchar2(256),
+  group_sql clob NOT NULL,
+  active number(1) NOT NULL,
+  source varchar2(256) NOT NULL,
+  private number(1) NOT NULL,
+  fpm_bldg_no varchar2(11) NOT NULL,
+  PRIMARY KEY (group_id)
+);
+
+CREATE SEQUENCE sq_t_message_message_id;
+
+CREATE TABLE t_message (
+  message_id number(11) NOT NULL,
+  alert_id number(11) NOT NULL,
+  from_address varchar2(256) NOT NULL,
+  recipient varchar2(64) NOT NULL,
+  subject_line varchar2(512) NOT NULL,
+  body_text clob NOT NULL,
+  body_html clob NOT NULL,
+  short_body varchar2(160) NOT NULL,
+  template_id number(11) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (message_id)
+);
+
+CREATE SEQUENCE sq_t_role_role_id;
+
+CREATE TABLE t_role (
+  role_id number(11) NOT NULL,
+  role_name varchar2(64) NOT NULL,
+  role_desc varchar2(128) NOT NULL,
+  PRIMARY KEY (role_id)
+);
+
+CREATE TABLE t_user (
+  user_id varchar2(32) NOT NULL,
+  name varchar2(256),
+  last4_pid varchar2(4) NOT NULL,
+  pidm number(11) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  mobile_phone varchar2(11),
+  mobile_phone_source varchar2(64),
+  reason_for_change varchar2(128),
+  im_id varchar2(512),
+  opt_in date,
+  opt_in_confirm date,
+  mobile_phone_2 varchar2(11),
+  PRIMARY KEY (user_id),
+  CONSTRAINT t_user_pidm UNIQUE (pidm)
+);
+
+CREATE SEQUENCE sq_t_alert_alert_id;
+
+CREATE TABLE t_alert (
+  alert_id number(11) NOT NULL,
+  category number(11) NOT NULL,
+  title varchar2(64) NOT NULL,
+  allow_email_opt_out number(1) NOT NULL,
+  enabled number(1) NOT NULL,
+  added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  added_by varchar2(32) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (alert_id)
+);
+
+CREATE TABLE t_category_defaults (
+  category_id number(11) NOT NULL,
+  user_id varchar2(32) NOT NULL,
+  default_email number(1) NOT NULL,
+  default_sms number(1) NOT NULL,
+  default_push number(1) NOT NULL,
+  default_im number(1) NOT NULL,
+  modified date,
+  modified_by varchar2(32),
+  PRIMARY KEY (category_id, user_id)
+);
+
+CREATE TABLE t_user_groups (
+  user_id varchar2(32) NOT NULL,
+  group_id number(11) NOT NULL,
+  PRIMARY KEY (user_id, group_id)
+);
+
+CREATE TABLE t_user_roles (
+  user_id varchar2(32) NOT NULL,
+  role_id number(11) NOT NULL,
+  PRIMARY KEY (user_id, role_id)
+);
+
+CREATE TABLE t_alert_roles (
+  alert_id number(11) NOT NULL,
+  role_id number(11) NOT NULL,
+  PRIMARY KEY (alert_id, role_id)
+);
+
+ALTER TABLE t_alert ADD CONSTRAINT t_alert_category_fk FOREIGN KEY (category) REFERENCES t_category (category_id);
+
+ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_category FOREIGN KEY (category_id) REFERENCES t_category (category_id);
+
+ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_user_id FOREIGN KEY (user_id) REFERENCES t_user (user_id);
+
+ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_group_id_fk FOREIGN KEY (group_id) REFERENCES t_group (group_id) ON DELETE CASCADE;
+
+ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_user_id_fk FOREIGN KEY (user_id) REFERENCES t_user (user_id) ON DELETE CASCADE;
+
+ALTER TABLE t_user_roles ADD CONSTRAINT t_user_roles_role_id_fk FOREIGN KEY (role_id) REFERENCES t_role (role_id) ON DELETE CASCADE;
+
+ALTER TABLE t_user_roles ADD CONSTRAINT t_user_roles_user_id_fk FOREIGN KEY (user_id) REFERENCES t_user (user_id) ON DELETE CASCADE;
+
+ALTER TABLE t_alert_roles ADD CONSTRAINT t_alert_roles_alert_id_fk FOREIGN KEY (alert_id) REFERENCES t_alert (alert_id) ON DELETE CASCADE;
+
+ALTER TABLE t_alert_roles ADD CONSTRAINT t_alert_roles_role_id_fk FOREIGN KEY (role_id) REFERENCES t_role (role_id);
+
+CREATE INDEX t_alert_idx_category on t_alert (category);
+
+CREATE INDEX t_category_defaults_idx_cate on t_category_defaults (category_id);
+
+CREATE INDEX t_category_defaults_idx_acce on t_category_defaults (user_id);
+
+CREATE INDEX t_user_groups_idx_group_id on t_user_groups (group_id);
+
+CREATE INDEX t_user_groups_idx_user_id on t_user_groups (user_id);
+
+CREATE INDEX t_user_roles_idx_role_id on t_user_roles (role_id);
+
+CREATE INDEX t_user_roles_idx_user_id on t_user_roles (user_id);
+
+CREATE INDEX t_alert_roles_idx_alert_id on t_alert_roles (alert_id);
+
+CREATE INDEX t_alert_roles_idx_role_id on t_alert_roles (role_id);
+
+CREATE OR REPLACE TRIGGER ai_t_group_group_id
+BEFORE INSERT ON t_group
+FOR EACH ROW WHEN (
+ new.group_id IS NULL OR new.group_id = 0
+)
+BEGIN
+ SELECT sq_t_group_group_id.nextval
+ INTO :new.group_id
+ FROM dual;
+END;
+/
+
+CREATE OR REPLACE TRIGGER ai_t_message_message_id
+BEFORE INSERT ON t_message
+FOR EACH ROW WHEN (
+ new.message_id IS NULL OR new.message_id = 0
+)
+BEGIN
+ SELECT sq_t_message_message_id.nextval
+ INTO :new.message_id
+ FROM dual;
+END;
+/
+
+CREATE OR REPLACE TRIGGER ai_t_role_role_id
+BEFORE INSERT ON t_role
+FOR EACH ROW WHEN (
+ new.role_id IS NULL OR new.role_id = 0
+)
+BEGIN
+ SELECT sq_t_role_role_id.nextval
+ INTO :new.role_id
+ FROM dual;
+END;
+/
+
+CREATE OR REPLACE TRIGGER ai_t_alert_alert_id
+BEFORE INSERT ON t_alert
+FOR EACH ROW WHEN (
+ new.alert_id IS NULL OR new.alert_id = 0
+)
+BEGIN
+ SELECT sq_t_alert_alert_id.nextval
+ INTO :new.alert_id
+ FROM dual;
+END;
+/
+

--- a/t/data/oracle/schema-1.6.sql
+++ b/t/data/oracle/schema-1.6.sql
@@ -129,11 +129,7 @@ ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_user_id FOREI
 
 ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_group_id_fk FOREIGN KEY (group_id) REFERENCES t_group (group_id) ON DELETE CASCADE;
 
-ALTER TABLE t_user_groups ADD CONSTRAINT t_user_groups_user_id_fk FOREIGN KEY (user_id) REFERENCES t_user (user_id) ON DELETE CASCADE;
-
 ALTER TABLE t_user_roles ADD CONSTRAINT t_user_roles_role_id_fk FOREIGN KEY (role_id) REFERENCES t_role (role_id) ON DELETE CASCADE;
-
-ALTER TABLE t_user_roles ADD CONSTRAINT t_user_roles_user_id_fk FOREIGN KEY (user_id) REFERENCES t_user (user_id) ON DELETE CASCADE;
 
 ALTER TABLE t_alert_roles ADD CONSTRAINT t_alert_roles_alert_id_fk FOREIGN KEY (alert_id) REFERENCES t_alert (alert_id) ON DELETE CASCADE;
 
@@ -152,8 +148,6 @@ CREATE INDEX t_user_groups_idx_user_id on t_user_groups (user_id);
 CREATE INDEX t_user_roles_idx_role_id on t_user_roles (role_id);
 
 CREATE INDEX t_user_roles_idx_user_id on t_user_roles (user_id);
-
-CREATE INDEX t_alert_roles_idx_alert_id on t_alert_roles (alert_id);
 
 CREATE INDEX t_alert_roles_idx_role_id on t_alert_roles (role_id);
 

--- a/t/data/oracle/schema-1.6.sql
+++ b/t/data/oracle/schema-1.6.sql
@@ -1,12 +1,12 @@
 CREATE TABLE t_category (
-  category_id number(11) NOT NULL,
+  id number(11) NOT NULL,
   display_name varchar2(256) NOT NULL,
   description varchar2(4000) NOT NULL,
   added date DEFAULT CURRENT_TIMESTAMP NOT NULL,
   added_by varchar2(32) NOT NULL,
   modified date,
   modified_by varchar2(32),
-  PRIMARY KEY (category_id)
+  PRIMARY KEY (id)
 );
 
 CREATE SEQUENCE sq_t_group_group_id;
@@ -121,9 +121,9 @@ CREATE TABLE t_alert_roles (
   PRIMARY KEY (alert_id, role_id)
 );
 
-ALTER TABLE t_alert ADD CONSTRAINT t_alert_category_fk FOREIGN KEY (category) REFERENCES t_category (category_id);
+ALTER TABLE t_alert ADD CONSTRAINT t_alert_category_fk FOREIGN KEY (category) REFERENCES t_category (id);
 
-ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_category FOREIGN KEY (category_id) REFERENCES t_category (category_id);
+ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_category FOREIGN KEY (category_id) REFERENCES t_category (id);
 
 ALTER TABLE t_category_defaults ADD CONSTRAINT t_category_defaults_user_id FOREIGN KEY (user_id) REFERENCES t_user (user_id);
 

--- a/t/data/oracle/schema_diff_b.yaml
+++ b/t/data/oracle/schema_diff_b.yaml
@@ -44,7 +44,7 @@ schema:
           data_type: nvarchar2
           default_value: ~
           extra: {}
-          is_nullable: 0
+          is_nullable: 1
           is_primary_key: 0
           is_unique: 0
           name: name

--- a/t/data/oracle/schema_diff_d.yaml
+++ b/t/data/oracle/schema_diff_d.yaml
@@ -71,3 +71,52 @@ schema:
             - 5
       name: d_operator
       order: 11
+    supplier:
+      constraints:
+        - fields: cust_id
+          name: fk_customer
+          reference_table: customer
+          reference_fields: 
+            - customer_id
+          type: FOREIGN KEY
+      fields:
+        id:
+          data_type: integer
+          is_nullable: 0
+          is_primary_key: 1
+          size: 11
+          name: id
+          order: 62
+        cust_id:
+          data_type: integer
+          is_nullable: 1
+          is_primary_key: 0
+          size: 11
+          name: cust_id
+          order: 63
+        supplier_name: 
+          data_type: nvarchar2
+          is_nullable: 0
+          is_primary_key: 0
+          size: 256
+          name: supplier_name
+          order: 64
+      name: supplier
+    customer:
+      fields:
+        customer_id:
+          data_type: integer
+          is_nullable: 0
+          is_primary_key: 1
+          size: 11
+          name: customer_id
+          order: 65
+        customer_name:
+          data_type: nvarchar2
+          is_nullable: 0
+          is_primary_key: 0
+          size: 256
+          name: customer_name
+          order: 66
+      name: customer
+      order: 12

--- a/t/data/oracle/schema_diff_d.yaml
+++ b/t/data/oracle/schema_diff_d.yaml
@@ -16,6 +16,13 @@ schema:
           reference_fields: []
           reference_table: ''
           type: PRIMARY KEY
+        - fields: foo
+          name: 'foo_unique'
+          type: UNIQUE
+        - fields: other
+          name: 'other_check'
+          type: CHECK
+          expression: other BETWEEN 1 and 99999
       fields:
         id_operator:
           data_type: integer
@@ -29,17 +36,6 @@ schema:
           order: 58
           size:
             - 0
-        bar:
-          data_type: varchar2
-          default_value: ~
-          extra: {}
-          is_nullable: 1
-          is_primary_key: 0
-          is_unique: 0
-          name: bar
-          order: 61
-          size:
-            - 3
         name:
           data_type: nvarchar2
           default_value: ~
@@ -51,16 +47,27 @@ schema:
           order: 59
           size:
             - 10
-        other:
+        foo:
           data_type: nvarchar2
           default_value: ~
           extra: {}
           is_nullable: 0
           is_primary_key: 0
-          is_unique: 0
-          name: other
+          is_unique: 1
+          name: foo
           order: 60
           size:
             - 10
+        other:
+          data_type: integer
+          default_value: ~
+          extra: {}
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: other
+          order: 61
+          size:
+            - 5
       name: d_operator
       order: 11

--- a/t/data/oracle/schema_diff_e.yaml
+++ b/t/data/oracle/schema_diff_e.yaml
@@ -68,3 +68,27 @@ schema:
             - 5
       name: d_operator
       order: 11
+    supplier:
+      fields:
+        id:
+          data_type: integer
+          is_nullable: 0
+          is_primary_key: 1
+          size: 11
+          name: id
+          order: 62
+        cust_id:
+          data_type: integer
+          is_nullable: 1
+          is_primary_key: 0
+          size: 11
+          name: cust_id
+          order: 63
+        supplier_name: 
+          data_type: nvarchar2
+          is_nullable: 0
+          is_primary_key: 0
+          size: 256
+          name: supplier_name
+          order: 65
+      name: supplier

--- a/t/data/oracle/schema_diff_e.yaml
+++ b/t/data/oracle/schema_diff_e.yaml
@@ -16,6 +16,10 @@ schema:
           reference_fields: []
           reference_table: ''
           type: PRIMARY KEY
+        - fields: other
+          name: 'other_check'
+          type: CHECK
+          expression: other BETWEEN 100 and 99999
       fields:
         id_operator:
           data_type: integer
@@ -29,17 +33,6 @@ schema:
           order: 58
           size:
             - 0
-        bar:
-          data_type: varchar2
-          default_value: ~
-          extra: {}
-          is_nullable: 1
-          is_primary_key: 0
-          is_unique: 0
-          name: bar
-          order: 61
-          size:
-            - 3
         name:
           data_type: nvarchar2
           default_value: ~
@@ -51,16 +44,27 @@ schema:
           order: 59
           size:
             - 10
-        other:
+        foo:
           data_type: nvarchar2
           default_value: ~
           extra: {}
           is_nullable: 0
           is_primary_key: 0
           is_unique: 0
-          name: other
+          name: foo
           order: 60
           size:
             - 10
+        other:
+          data_type: integer
+          default_value: ~
+          extra: {}
+          is_nullable: 0
+          is_primary_key: 0
+          is_unique: 1
+          name: other
+          order: 61
+          size:
+            - 5
       name: d_operator
       order: 11


### PR DESCRIPTION
Adds functionality to Producer/Oracle.pm to:
- Alter create constraints
- Alter drop constraints
- Drop fields
- Drop tables
- Alter create index
- Alter drop index

Related tests have been added to prove changes and all existing tests pass.
Automatic creation of trigger to insert sysdate to all timestamp fields has been commented out. That should not be done automatically. 

Changes were modeled after the structure of Producer/MySQL.pm.

This branch also includes changes from pull request #142 