### PR TITLE
JSON & YAML parsers now add table comments.

### DIFF
--- a/lib/SQL/Translator/Parser/JSON.pm
+++ b/lib/SQL/Translator/Parser/JSON.pm
@@ -56,6 +56,10 @@ sub parse {
         for my $cdata ( @{ $tdata->{'constraints'} || [] } ) {
             $table->add_constraint( %$cdata ) or die $table->error;
         }
+
+	$table->comments( $tdata->{'comments' } )
+	    if exists $tdata->{'comments'};
+
     }
 
     #

--- a/lib/SQL/Translator/Parser/YAML.pm
+++ b/lib/SQL/Translator/Parser/YAML.pm
@@ -56,6 +56,9 @@ sub parse {
         for my $cdata ( @{ $tdata->{'constraints'} || [] } ) {
             $table->add_constraint( %$cdata ) or die $table->error;
         }
+
+	$table->comments( $tdata->{'comments' } )
+	    if exists $tdata->{'comments'};
     }
 
     #

--- a/lib/SQL/Translator/Producer/JSON.pm
+++ b/lib/SQL/Translator/Producer/JSON.pm
@@ -133,8 +133,8 @@ sub view_procedure {
         'sql'        => scalar $procedure->sql,
         'parameters' => scalar $procedure->parameters,
         'owner'      => scalar $procedure->owner,
-        'comments'   => scalar $procedure->comments,
-        keys %{$procedure->extra} ? ('extra' => { $procedure->extra } ) : (),
+        $procedure->comments      ? ('comments' => [ $procedure->comments ] ) : (),
+        keys %{$procedure->extra} ? ('extra'    => { $procedure->extra } ) : (),
     };
 }
 

--- a/lib/SQL/Translator/Producer/YAML.pm
+++ b/lib/SQL/Translator/Producer/YAML.pm
@@ -132,8 +132,8 @@ sub view_procedure {
         'sql'        => scalar $procedure->sql,
         'parameters' => scalar $procedure->parameters,
         'owner'      => scalar $procedure->owner,
-        'comments'   => scalar $procedure->comments,
-        keys %{$procedure->extra} ? ('extra' => { $procedure->extra } ) : (),
+        $procedure->comments      ? ('comments' => [ $procedure->comments ] ) : (),
+        keys %{$procedure->extra} ? ('extra'    => { $procedure->extra } ) : (),
     };
 }
 


### PR DESCRIPTION
1. The JSON and YAML parsers didn't add table comments.
2. The `procedure` producers for JSON & YAML created a single string out of multi-line comments, rather than an array of comments. 

