### PR TITLE
don't pass non-JSON specific producer_args to to_json

### DIFF
--- a/lib/SQL/Translator/Producer/JSON.pm
+++ b/lib/SQL/Translator/Producer/JSON.pm
@@ -61,7 +61,9 @@ sub produce {
     }, {
         allow_blessed => 1,
         allow_unknown => 1,
-        %{$translator->producer_args},
+        ( map { $_ => $translator->producer_args->{$_} }
+	  grep { defined $translator->producer_args->{$_} }
+	    qw[ pretty indent canonical ] ),
     });
 }
 

--- a/t/23json.t
+++ b/t/23json.t
@@ -281,7 +281,8 @@ my $json = from_json(<<JSON);
       "parser_type" : "SQL::Translator::Parser::SQLite",
       "producer_args" : {
          "canonical" : 1,
-         "pretty" : 1
+         "pretty" : 1,
+	 "totally_bogus_arg_to_test_arg_filtering_to_json" : 1
       },
       "producer_type" : "SQL::Translator::Producer::JSON",
       "show_warnings" : 0,
@@ -301,6 +302,7 @@ my $tr = SQL::Translator->new(
     producer_args => {
         canonical => 1,
         pretty => 1,
+	totally_bogus_arg_to_test_arg_filtering_to_json => 1,
     },
     data => $data,
 );


### PR DESCRIPTION
The producer_args passed by sqlt contains a number of keys which are not specific to JSON.  These were passed unfiltered to to_json(). JSON (at least as of v2.90) will throw an error if it is passed an unknown option (it uses the option key as a method name, which leads to confusing error messages).

It's not straightforward to automatically determine the args supported by the JSON module, so this simply whitelist the 'pretty', 'indent', and 'canonical' options.