### PR TITLE
Fix bugs in Parser::DBI::PostgreSQL data_type, size, and default_value

### DIFF
--- a/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
+++ b/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
@@ -142,7 +142,7 @@ ORDER BY 1;
                 elsif ($default =~ /^'(.*?)'(::\Q$type\E)?$/) {
                     my $str= $1;
                     $str =~ s/''/'/g;
-                    $col->default_value($1)
+                    $col->default_value($str);
                 }
                 else { $col->default_value(\$default) }
             }

--- a/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
+++ b/lib/SQL/Translator/Parser/DBI/PostgreSQL.pm
@@ -127,7 +127,8 @@ ORDER BY 1;
 
             my $col = $table->add_field(
                               name        => $$columnhash{'attname'},
-                              default_value => $$columnhash{'adsrc'},
+                              (!$$columnhash{'atthasdef'}? ()
+                              : ( default_value => \$$columnhash{'adsrc'} )),
                               data_type   => $$columnhash{'typname'},
                               order       => $$columnhash{'attnum'},
                              ) || die $table->error;

--- a/t/66-postgres-dbi-parser.t
+++ b/t/66-postgres-dbi-parser.t
@@ -53,7 +53,7 @@ my $sql = q[
 
     CREATE TABLE sqlt_products_1 (
         product_no integer,
-        name text,
+        name text default '['''']',
         price numeric(8,4) default 0.0,
         created_at timestamp without time zone default now()
     );
@@ -166,6 +166,11 @@ isa_ok( $fk_ref1, 'SQL::Translator::Schema::Constraint', 'FK' );
 is( $fk_ref1->reference_table, 'sqlt_test1', 'FK is to "sqlt_test1" table' );
 
 my $t3 = $schema->get_table("sqlt_products_1");
+
+my $t3_f2= $t3->get_field('name');
+is( $t3_f2->data_type, 'text', 'Second field, type "text"' );
+is( $t3_f2->default_value, q{['']}, 'default value is json array of empty string' );
+
 my $t3_f3= $t3->get_field('price');
 is( $t3_f3->name, 'price', 'Third field is "price"' );
 is( $t3_f3->data_type, 'numeric', 'Third field type "numeric"' );

--- a/t/66-postgres-dbi-parser.t
+++ b/t/66-postgres-dbi-parser.t
@@ -93,7 +93,7 @@ my $f1 = shift @t1_fields;
 is( $f1->name, 'f_serial', 'First field is "f_serial"' );
 is( $f1->data_type, 'integer', 'Field is an integer' );
 is( $f1->is_nullable, 0, 'Field cannot be null' );
-is( $f1->default_value, "nextval('sqlt_test1_f_serial_seq'::regclass)", 'Default value is nextval()' );
+is( ${$f1->default_value}, "nextval('sqlt_test1_f_serial_seq'::regclass)", 'Default value is nextval()' );
 is( $f1->is_primary_key, 1, 'Field is PK' );
 #FIXME: not set to auto-increment? maybe we can guess auto-increment behavior by looking at the default_value (i.e. it call function nextval() )
 #is( $f1->is_auto_increment, 1, 'Field is auto increment' );
@@ -114,7 +114,7 @@ is( $f3->name, 'f_text', 'Third field is "f_text"' );
 is( $f3->data_type, 'text', 'Field is a text' );
 is( $f3->is_nullable, 1, 'Field can be null' );
 is( $f3->size, 0, 'Size is 0' );
-is( $f3->default_value, "'FOO'::text", 'Default value is "FOO"' );
+is( ${$f3->default_value}, "'FOO'::text", 'Default value is "FOO"' );
 is( $f3->is_primary_key, 0, 'Field is not PK' );
 is( $f3->is_auto_increment, 0, 'Field is not auto increment' );
 is( $f3->comments, 'this is a comment on a field of the first table', 'There is a comment on the third field');


### PR DESCRIPTION
I'm rather surprised to find bugs this large, so please review and see if I have any wrong assumptions here.

I'm running into cases where postgres round-trip from a DBI connection was generating a lot of syntax errors.  It seems to have broken handling of column types with sizes, and broken handling of default values for anything other than numeric constants.

The changes are maybe best described by the changes to unit test 66.  You can see that the parser used to store char column size in the data_type instead of ->size field, and have an incorrect value in the ->size field, and store literal DDL as plain strings for the default_value.  I changed these to behave like other parsers and put the real size in the size column, and use scalar-refs for any default value that is literal DDL.