### PR TITLE
Round-trip AUTOINCREMENT in SQLite parser

### DIFF
--- a/lib/SQL/Translator/Parser/SQLite.pm
+++ b/lib/SQL/Translator/Parser/SQLite.pm
@@ -681,6 +681,7 @@ sub parse {
                 size              => $fdata->{'size'},
                 default_value     => $fdata->{'default'},
                 is_auto_increment => $fdata->{'is_auto_inc'},
+		($fdata->{'is_auto_inc'}? ( extra => { auto_increment_type => 'monotonic' } ) : ()),
                 is_nullable       => $fdata->{'is_nullable'},
                 comments          => $fdata->{'comments'},
             ) or die $table->error;

--- a/t/23json.t
+++ b/t/23json.t
@@ -109,6 +109,9 @@ my $json = from_json(<<JSON);
                     "field comment 2"
                   ],
                   "data_type" : "INTEGER",
+                  "extra" : {
+                     "auto_increment_type" : "monotonic"
+                  },
                   "default_value" : null,
                   "is_auto_increment" : 1,
                   "is_nullable" : 0,

--- a/t/24yaml.t
+++ b/t/24yaml.t
@@ -100,6 +100,8 @@ schema:
           order: 1
           size:
             - 0
+          extra:
+            auto_increment_type: monotonic
         weight:
           data_type: double
           default_value: ~


### PR DESCRIPTION
Currently, the SQLite parser sees the AUTOINCREMENT keyword and sets the column flag is_auto_increment, but the SQLite Producer will not write the AUTOINCREMENT keyword unless extra.auto_increment_type is 'monotonic'.  This breaks round-trip by the AUTOINCREMENT keyword getting lost.

This was mentioned as a needed related fix in the discussion of #47, but it seems to have never been added.