### PR TITLE
untabify lib/SQL/Translator/Parser/SQLite.pm

### DIFF
--- a/lib/SQL/Translator/Parser/SQLite.pm
+++ b/lib/SQL/Translator/Parser/SQLite.pm
@@ -681,7 +681,7 @@ sub parse {
                 size              => $fdata->{'size'},
                 default_value     => $fdata->{'default'},
                 is_auto_increment => $fdata->{'is_auto_inc'},
-		($fdata->{'is_auto_inc'}? ( extra => { auto_increment_type => 'monotonic' } ) : ()),
+                ($fdata->{'is_auto_inc'}? ( extra => { auto_increment_type => 'monotonic' } ) : ()),
                 is_nullable       => $fdata->{'is_nullable'},
                 comments          => $fdata->{'comments'},
             ) or die $table->error;


### PR DESCRIPTION
xt/notabs.t currently fails (if Test::NoTabs is installed) with:
```
#   Failed test 'No tabs in 'lib/SQL/Translator/Parser/SQLite.pm' on line 684'
#   at /opt/perl-5.30.3/lib/site_perl/5.30.3/Test/NoTabs.pm line 89.
```
