### PR TITLE
Improve SQLite grammar for check constraints

### DIFF
--- a/t/23json.t
+++ b/t/23json.t
@@ -147,8 +147,8 @@ my $json = from_json(<<JSON);
             "constraints" : [
                {
                   "deferrable" : 1,
-                  "expression" : "",
-                  "fields" : [],
+                  "expression" : "age < 100",
+                  "fields" : ["age"],
                   "match_type" : "",
                   "name" : "",
                   "on_delete" : "",

--- a/t/24yaml.t
+++ b/t/24yaml.t
@@ -122,8 +122,8 @@ schema:
     pet:
       constraints:
         - deferrable: 1
-          expression: ''
-          fields: []
+          expression: 'age < 100'
+          fields: ['age']
           match_type: ''
           name: ''
           on_delete: ''

--- a/t/27sqlite-parser.t
+++ b/t/27sqlite-parser.t
@@ -10,7 +10,7 @@ use SQL::Translator;
 use SQL::Translator::Schema::Constants;
 
 BEGIN {
-  maybe_plan(26, 'SQL::Translator::Parser::SQLite');
+  maybe_plan(64, 'SQL::Translator::Parser::SQLite');
 }
 SQL::Translator::Parser::SQLite->import('parse');
 
@@ -49,6 +49,12 @@ my $file = "$Bin/data/sqlite/create.sql";
   is($c1->reference_table,             'person',      'References person table');
   is(join(',', $c1->reference_fields), 'person_id',   'References person_id field');
 
+  my $c0 = shift @constraints;
+  is($c0->type,       'CHECK',     'CHECK constraint');
+  is($c0->expression, 'age < 100', 'contraint expression');
+  is_deeply([ $c0->field_names ], ['age'], 'fields that check refers to');
+  is($c0->table, 'pet', 'table name is pet');
+
   my @views = $schema->get_views;
   is(scalar @views, 1, 'Parsed one views');
 
@@ -75,6 +81,13 @@ $file = "$Bin/data/sqlite/named.sql";
   my @constraints = $t1->get_constraints;
   is(scalar @constraints, 5, '5 constraints on pet');
 
+  my $c0 = $constraints[0];
+  is($c0->type, 'CHECK',         'constraint has correct type');
+  is($c0->name, 'age_under_100', 'constraint check has correct name');
+  is_deeply([ $c0->field_names ], ['age'], 'fields that check refers to');
+  is($c0->table,      'pet',                                 'table name is pet');
+  is($c0->expression, 'age < 100 and age not in (101, 102)', 'constraint expression');
+
   my $c1 = $constraints[2];
   is($c1->type,                        'FOREIGN KEY',  'FK constraint');
   is($c1->reference_table,             'person',       'References person table');
@@ -91,4 +104,46 @@ $file = "$Bin/data/sqlite/named.sql";
   is($c3->on_update, 'NO ACTION', 'On update no action');
   is($c3->on_delete, '',          'On delete not defined');
 
+}
+
+$file = "$Bin/data/sqlite/checks.sql";
+{
+  local $/;
+  open my $fh, "<$file" or die "Can't read file '$file': $!\n";
+  my $data = <$fh>;
+  my $t    = SQL::Translator->new(trace => 0, debug => 0);
+  parse($t, $data);
+
+  my $schema = $t->schema;
+
+  my @tables = $schema->get_tables;
+  is(scalar @tables, 2, 'Parsed one table');
+
+  is($tables[0]->name, 'pet',        "'Pet' table");
+  is($tables[1]->name, 'zoo_animal', "'Zoo Amimal' table");
+
+  for my $t1 (@tables) {
+    my @fields = $t1->get_fields;
+    is(scalar @fields, 4, 'Four fields in "pet" table');
+
+    my $visits = $fields[3];
+    is($visits->name,          'vet_visits', 'field name correct');
+    is($visits->default_value, '[]',         'default value is empty array');
+    is($visits->is_nullable,   0,            'not null');
+
+    my @constraints = $t1->get_constraints;
+    is(scalar @constraints, 2, '2 constraints on pet');
+
+    my $c0 = $constraints[0];
+    is($c0->type, 'CHECK', 'constraint has correct type');
+    is_deeply([ $c0->field_names ], ['vet_visits'], 'fields that check refers to');
+    is($c0->table,      $t1->name,                                                     'table name is pet');
+    is($c0->expression, q{json_valid(vet_visits) and json_type(vet_visits) = 'array'}, 'constraint expression');
+
+    my $c1 = $constraints[1];
+    is($c1->type,              'PRIMARY KEY',      'PK constraint');
+    is($c1->table,             $t1->name,          'pet table');
+    is($c1->name,              'pk_pet',           'Constraint name pk_pet');
+    is(join(',', $c1->fields), 'pet_id,person_id', 'References person_id field');
+  }
 }

--- a/t/data/sqlite/checks.sql
+++ b/t/data/sqlite/checks.sql
@@ -1,0 +1,16 @@
+create table pet (
+  "pet_id" int,
+  "person_id" int,
+  "name" varchar(30),
+  "vet_visits" text not null check(json_valid(vet_visits) and json_type(vet_visits) = 'array') default '[]',
+  constraint pk_pet primary key (pet_id, person_id)
+);
+
+create table zoo_animal (
+    "pet_id" int,
+    "person_id" int,
+    "name" varchar(30),
+    "vet_visits" text not null default '[]',
+    constraint ck_json_array check(json_valid(vet_visits) and json_type(vet_visits) = 'array'),
+    constraint pk_pet primary key (pet_id, person_id)
+);


### PR DESCRIPTION
Improve the SQLite grammar and support for check constraints.

This PR updates the grammar to parse check constraints with function calls, such as, `check(json_valid(vet_visits) and json_type(vet_visits) = 'array')`.

Additionally, the expression and fields properties on the constraint object are set, whether the constraint is specified as part of a column definition, or separately within the table definition.