### PR TITLE
fix precedence error in SQL::Translator::Schema::Trigger

### DIFF
--- a/lib/SQL/Translator/Schema/Trigger.pm
+++ b/lib/SQL/Translator/Schema/Trigger.pm
@@ -356,7 +356,7 @@ around equals => sub {
     return $self->error('Names not equal');
   }
 
-  if (!$self->perform_action_when eq $other->perform_action_when) {
+  if ($self->perform_action_when ne $other->perform_action_when) {
     return $self->error('perform_action_when differs');
   }
 


### PR DESCRIPTION
`!$x eq $y` parses as `(!$x) eq $y`, not `!($x eq $y)`. Just use `ne` to check for inequality directly.

Fixes #175.