### PR TITLE
Print meaningfull error message

### DIFF
--- a/t/60roundtrip.t
+++ b/t/60roundtrip.t
@@ -93,7 +93,7 @@ my $plan = [
 # This data file has the right mix of table/view/procedure/trigger
 # definitions, and lists enough quirks to trip up most combos
 my $base_file = "$Bin/data/roundtrip_autogen.yaml";
-open(my $base_fh, '<', $base_file) or die "$base_file: $!";
+open(my $base_fh, '<', $base_file) or die "$base_file: $!\nHINT: Run `perl Makefile.PL` to recreate it.";
 
 my $base_t = SQL::Translator->new;
 $base_t->$_(1) for qw/add_drop_table no_comments quote_identifiers/;


### PR DESCRIPTION
### Problem
During tests we get unclear error message: 
```
/home/kes/work/projects/github-forks/sql-translator/t/data/roundtrip_autogen.yaml: No such file or directory at t/60roundtrip.t line 96.
```
It is problematic to understand what is the file and how to get it.

### Solution
Provide the instruction to user how to regenerate this file. The similar attempt we can see from PostgreSQL error messages where `HINT` provides some direction to users to resolve a problem.