### PR TITLE
Test on the latest stable perl 5.42 too

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,6 +16,7 @@ jobs:
           - '5.32'
           - '5.34'
           - '5.36'
+          - '5.42'
     container:
       image: perl:${{ matrix.perl-version }}
     steps:


### PR DESCRIPTION
As of 2025 the latest stable perl is 5.42. Adding it into CI loop.