### PR TITLE
Fix command line parameter handling

### DIFF
--- a/script/sqlt
+++ b/script/sqlt
@@ -246,6 +246,13 @@ GetOptions(
   'mysql-version=f'                     => \$mysql_version,
 ) or pod2usage(2);
 
+pod2usage(1) if $help;
+
+if ($show_version) {
+  print "SQL::Translator v", $SQL::Translator::VERSION, "\n";
+  exit(0);
+}
+
 if ($use_same_auth) {
   $producer_dsn         = $dsn;
   $producer_db_user     = $db_user;
@@ -264,13 +271,6 @@ unless (@files) {
   } else {
     @files = ('-');
   }
-}
-
-pod2usage(1) if $help;
-
-if ($show_version) {
-  print "SQL::Translator v", $SQL::Translator::VERSION, "\n";
-  exit(0);
 }
 
 my $translator = SQL::Translator->new(


### PR DESCRIPTION
Examples of current behaviour:

```
$ perl -Ilib script/sqlt --help | head -4
Use of uninitialized value $from in pattern match (m//) at script/sqlt line 258.
Usage:
    For help:

      sqlt -h|--help
```

```
$ perl -Ilib script/sqlt --version
Use of uninitialized value $from in pattern match (m//) at script/sqlt line 258. SQL::Translator v1.66
```
